### PR TITLE
Make reportr change the URL when selecting an interval

### DIFF
--- a/src/modules/reportr/employee-hours.tpl.html
+++ b/src/modules/reportr/employee-hours.tpl.html
@@ -1,7 +1,7 @@
 <h1 translate="PAGES.REPORTR.EMPLOYEE_HOURS.TITLE"></h1>
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
-        <date-interval callback="dateSelected"></date-interval>
+        <date-interval start-date="interval.start" end-date="interval.end" callback="dateSelected"></date-interval>
     </div>
 </div>
 <div class="space-md"/>

--- a/src/modules/reportr/employeeHoursController.js
+++ b/src/modules/reportr/employeeHoursController.js
@@ -1,10 +1,11 @@
-define(['moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper'], function(moment, LodashHelpers, SortHelper) {
+define(['moment', './lodashHelpers', './sortHelper'], function(moment, LodashHelpers, SortHelper) {
     'use strict';
-    return ['$scope', 'Restangular', '$filter', function($scope, Restangular, $filter) {
+    var employeeHoursController = function($scope, Restangular, $filter, intervalLocationService) {
         var controller = this;
 
         // see date-interval directive
         $scope.dateSelected = function(start, end) {
+            intervalLocationService.saveIntervalToLocation(start, end);
             controller.loadWorkTimes(start, end);
         };
 
@@ -85,6 +86,9 @@ define(['moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper']
             }
         };
 
-        controller.loadWorkTimes(moment().startOf('month').toDate(), moment().endOf('month').toDate());
-    }];
+        $scope.interval = intervalLocationService.loadIntervalFromLocation();
+        controller.loadWorkTimes($scope.interval.start, $scope.interval.end);
+    };
+    employeeHoursController.$inject = ['$scope', 'Restangular', '$filter', 'reportr.intervalLocationService'];
+    return employeeHoursController;
 });

--- a/src/modules/reportr/expenses-debitor.tpl.html
+++ b/src/modules/reportr/expenses-debitor.tpl.html
@@ -1,7 +1,7 @@
 <h1 translate="PAGES.REPORTR.EXPENSES_DEBITOR.TITLE"></h1>
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
-        <date-interval callback="dateSelected"></date-interval>
+        <date-interval start-date="interval.start" end-date="interval.end" callback="dateSelected"></date-interval>
     </div>
 </div>
 <div class="space-md"/>

--- a/src/modules/reportr/expensesDebitorController.js
+++ b/src/modules/reportr/expensesDebitorController.js
@@ -1,10 +1,11 @@
-define(['lodash', 'moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper'], function(_, moment, LodashHelpers, SortHelper) {
+define(['lodash', './lodashHelpers', './sortHelper'], function(_, LodashHelpers, SortHelper) {
     'use strict';
-    return ['$scope', 'Restangular', '$filter', function($scope, Restangular, $filter) {
+    var expensesDebitorController = function($scope, Restangular, $filter, intervalLocationService) {
         var controller = this;
 
         // see date-interval directive
         $scope.dateSelected = function(start, end) {
+            intervalLocationService.saveIntervalToLocation(start, end);
             controller.loadTravelExpenseReports(start, end);
         };
 
@@ -91,6 +92,9 @@ define(['lodash', 'moment', 'modules/reportr/lodashHelpers', 'modules/reportr/so
             }
         };
 
-        controller.loadTravelExpenseReports(moment().startOf('month').toDate(), moment().endOf('month').toDate());
-    }];
+        $scope.interval = intervalLocationService.loadIntervalFromLocation();
+        controller.loadTravelExpenseReports($scope.interval.start, $scope.interval.end);
+    };
+    expensesDebitorController.$inject = ['$scope', 'Restangular', '$filter', 'reportr.intervalLocationService'];
+    return expensesDebitorController;
 });

--- a/src/modules/reportr/intervalLocationService.js
+++ b/src/modules/reportr/intervalLocationService.js
@@ -1,0 +1,38 @@
+define(['moment', 'angular'], function(moment, angular) {
+    'use strict';
+    var intervalLocationService = function($location) {
+
+        /**
+         * Loads a time interval from the URL search from the parameters 'start' and 'end'. If not found
+         * the first day of month resp. last day of month is returned.
+         *
+         * @returns {{start: *, end: *}}
+         */
+        this.loadIntervalFromLocation = function() {
+            var interval = {
+                start: moment().startOf('month').toDate(),
+                end: moment().endOf('month').toDate()
+            };
+            var search = $location.search();
+            if(angular.isString(search.start)) {
+                interval.start = moment(search.start).toDate();
+            }
+            if(angular.isString(search.end)) {
+                interval.end = moment(search.end).toDate();
+            }
+            return interval;
+        };
+
+        /**
+         * Save an interval into the URL search (format YYYY-MM-DD) in the parameters 'start' and 'end'.
+         * @param start {Date} The start for the interval.
+         * @param end {Date} The end for the interval.
+         */
+        this.saveIntervalToLocation = function(start, end) {
+            $location.search('start', moment(start).format('YYYY-MM-DD'));
+            $location.search('end', moment(end).format('YYYY-MM-DD'));
+        };
+    };
+    intervalLocationService.$inject = ['$location'];
+    return intervalLocationService;
+});

--- a/src/modules/reportr/project-hours.tpl.html
+++ b/src/modules/reportr/project-hours.tpl.html
@@ -1,7 +1,7 @@
 <h1 translate="PAGES.REPORTR.PROJECT_HOURS.TITLE"></h1>
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
-        <date-interval callback="dateSelected"></date-interval>
+        <date-interval start-date="interval.start" end-date="interval.end" callback="dateSelected"></date-interval>
     </div>
 </div>
 <div class="space-md"/>

--- a/src/modules/reportr/projectHoursController.js
+++ b/src/modules/reportr/projectHoursController.js
@@ -1,10 +1,11 @@
-define(['moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper'], function(moment, LodashHelpers, SortHelper) {
+define(['moment', './lodashHelpers', './sortHelper'], function(moment, LodashHelpers, SortHelper) {
     'use strict';
-    return ['$scope', 'Restangular', '$filter', function($scope, Restangular, $filter) {
+    var projectHoursController = function($scope, Restangular, $filter, intervalLocationService) {
         var controller = this;
 
         // see date-interval directive
         $scope.dateSelected = function(start, end) {
+            intervalLocationService.saveIntervalToLocation(start, end);
             controller.loadAllTimes(start, end);
         };
 
@@ -136,6 +137,9 @@ define(['moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper']
             }
         };
 
-        controller.loadAllTimes(moment().startOf('month').toDate(), moment().endOf('month').toDate());
-    }];
+        $scope.interval = intervalLocationService.loadIntervalFromLocation();
+        controller.loadAllTimes($scope.interval.start, $scope.interval.end);
+    };
+    projectHoursController.$inject = ['$scope', 'Restangular', '$filter', 'reportr.intervalLocationService'];
+    return projectHoursController;
 });

--- a/src/modules/reportr/reportrModule.js
+++ b/src/modules/reportr/reportrModule.js
@@ -6,8 +6,9 @@ define(['angular',
     'modules/reportr/travelExpenseController',
     'modules/reportr/expensesDebitorController',
     'modules/reportr/sickDaysController',
+    './intervalLocationService',
     'angular-charts'
-], function(angular, RevenueController, VacationController, ProjectHoursController, EmployeeHoursController, TravelExpenseController, ExpensesDebitorController, SickDaysController) {
+], function(angular, RevenueController, VacationController, ProjectHoursController, EmployeeHoursController, TravelExpenseController, ExpensesDebitorController, SickDaysController, intervalLocationService) {
     'use strict';
     var configFn = ['angularCharts'];
     var reportr = angular.module('reportr', configFn);
@@ -20,6 +21,7 @@ define(['angular',
     reportr.controller('reportr.controllers.expenses-debitor', ExpensesDebitorController);
     reportr.controller('reportr.controllers.sick-days', SickDaysController);
 
+    reportr.service('reportr.intervalLocationService', intervalLocationService);
     reportr.config(['$stateProvider', function($stateProvider) {
         $stateProvider
             .state('app.reportr', {

--- a/src/modules/reportr/revenue.tpl.html
+++ b/src/modules/reportr/revenue.tpl.html
@@ -1,7 +1,7 @@
 <h1 translate="PAGES.REPORTR.REVENUE.TITLE"></h1>
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
-        <date-interval callback="dateSelected"></date-interval>
+        <date-interval start-date="interval.start" end-date="interval.end" callback="dateSelected"></date-interval>
     </div>
 </div>
 <div class="space-md"/>

--- a/src/modules/reportr/revenueController.js
+++ b/src/modules/reportr/revenueController.js
@@ -1,10 +1,11 @@
-define(['moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper'], function(moment, LodashHelpers, SortHelper) {
+define(['./lodashHelpers', './sortHelper'], function(LodashHelpers, SortHelper) {
     'use strict';
-    return ['Restangular', '$scope', function(Restangular, $scope) {
+    var revenueController = function(Restangular, $scope, intervalLocationService) {
         var controller = this;
 
         // see date-interval directive
         $scope.dateSelected = function(start, end) {
+            intervalLocationService.saveIntervalToLocation(start, end);
             controller.loadInvoices(start, end);
         };
 
@@ -73,6 +74,9 @@ define(['moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper']
 
         $scope.totalRevenue = 0;
 
-        controller.loadInvoices(moment().startOf('month').toDate(), moment().endOf('month').toDate());
-    }];
+        $scope.interval = intervalLocationService.loadIntervalFromLocation();
+        controller.loadInvoices($scope.interval.start, $scope.interval.end);
+    };
+    revenueController.$inject = ['Restangular', '$scope', 'reportr.intervalLocationService'];
+    return revenueController;
 });

--- a/src/modules/reportr/sick-days.tpl.html
+++ b/src/modules/reportr/sick-days.tpl.html
@@ -1,7 +1,7 @@
 <h1 translate="PAGES.REPORTR.SICK_DAYS.TITLE"></h1>
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
-        <date-interval callback="dateSelected"></date-interval>
+        <date-interval start-date="interval.start" end-date="interval.end" callback="dateSelected"></date-interval>
     </div>
 </div>
 <div class="space-md"/>

--- a/src/modules/reportr/sickDaysController.js
+++ b/src/modules/reportr/sickDaysController.js
@@ -1,9 +1,10 @@
-define(['moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper'], function(moment, LodashHelpers, SortHelper) {
+define(['moment', './lodashHelpers', './sortHelper'], function(moment, LodashHelpers, SortHelper) {
     'use strict';
-    return ['$scope', 'Restangular', '$filter', function($scope, Restangular, $filter) {
+    var sickDaysController = function($scope, Restangular, $filter, intervalLocationService) {
         var controller = this;
 
         $scope.dateSelected = function(start, end) {
+            intervalLocationService.saveIntervalToLocation(start, end);
             controller.loadSickDays(start, end);
         };
 
@@ -73,6 +74,9 @@ define(['moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper']
             }
         };
 
-        controller.loadSickDays(moment().startOf('month').toDate(), moment().endOf('month').toDate());
-    }];
+        $scope.interval = intervalLocationService.loadIntervalFromLocation();
+        controller.loadSickDays($scope.interval.start, $scope.interval.end);
+    };
+    sickDaysController.$inject = ['$scope', 'Restangular', '$filter', 'reportr.intervalLocationService'];
+    return sickDaysController;
 });

--- a/src/modules/reportr/travel-expense.tpl.html
+++ b/src/modules/reportr/travel-expense.tpl.html
@@ -1,7 +1,7 @@
 <h1 translate="PAGES.REPORTR.TRAVEL_EXPENSE.TITLE"></h1>
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
-        <date-interval callback="dateSelected"></date-interval>
+        <date-interval start-date="interval.start" end-date="interval.end" callback="dateSelected"></date-interval>
     </div>
 </div>
 <div class="space-md"/>

--- a/src/modules/reportr/travelExpenseController.js
+++ b/src/modules/reportr/travelExpenseController.js
@@ -1,10 +1,11 @@
-define(['lodash', 'moment', 'modules/reportr/lodashHelpers', 'modules/reportr/sortHelper'], function(_, moment, LodashHelpers, SortHelper) {
+define(['lodash', './lodashHelpers', './sortHelper'], function(_, LodashHelpers, SortHelper) {
     'use strict';
-    return ['$scope', 'Restangular', '$filter', function($scope, Restangular, $filter) {
+    var travelExpenseController = function($scope, Restangular, $filter, intervalLocationService) {
         var controller = this;
 
         // see date-interval directive
         $scope.dateSelected = function(start, end) {
+            intervalLocationService.saveIntervalToLocation(start, end);
             controller.loadTravelExpenseReports(start, end);
         };
 
@@ -91,6 +92,9 @@ define(['lodash', 'moment', 'modules/reportr/lodashHelpers', 'modules/reportr/so
             }
         };
 
-        controller.loadTravelExpenseReports(moment().startOf('month').toDate(), moment().endOf('month').toDate());
-    }];
+        $scope.interval = intervalLocationService.loadIntervalFromLocation();
+        controller.loadTravelExpenseReports($scope.interval.start, $scope.interval.end);
+    };
+    travelExpenseController.$inject = ['$scope', 'Restangular', '$filter', 'reportr.intervalLocationService'];
+    return travelExpenseController;
 });

--- a/src/modules/reportr/vacation.tpl.html
+++ b/src/modules/reportr/vacation.tpl.html
@@ -1,7 +1,7 @@
 <h1 translate="PAGES.REPORTR.VACATION.TITLE"></h1>
 <div class="row">
     <div class="col-md-6 col-md-offset-3">
-        <date-interval callback="dateSelected"></date-interval>
+        <date-interval start-date="interval.start" end-date="interval.end" callback="dateSelected"></date-interval>
     </div>
 </div>
 <div class="space-md"/>

--- a/src/modules/reportr/vacationController.js
+++ b/src/modules/reportr/vacationController.js
@@ -1,10 +1,11 @@
-define(['lodash', 'moment', 'modules/reportr/sortHelper'], function(_, moment, SortHelper) {
+define(['lodash', './sortHelper'], function(_, SortHelper) {
     'use strict';
-    return ['$http', '$scope', '$filter', function($http, $scope, $filter) {
+    var vacationController = function($http, $scope, $filter, intervalLocationService) {
         var controller = this;
 
         // see date-interval directive
         $scope.dateSelected = function(start, end) {
+            intervalLocationService.saveIntervalToLocation(start, end);
             controller.loadVacationRequests(start, end);
         };
 
@@ -71,6 +72,10 @@ define(['lodash', 'moment', 'modules/reportr/sortHelper'], function(_, moment, S
             }
         };
 
-        controller.loadVacationRequests(moment().startOf('month').toDate(), moment().endOf('month').toDate());
-    }];
+        $scope.interval = intervalLocationService.loadIntervalFromLocation();
+        controller.loadVacationRequests($scope.interval.start, $scope.interval.end);
+    };
+
+    vacationController.$inject = ['$http', '$scope', '$filter', 'reportr.intervalLocationService'];
+    return vacationController;
 });

--- a/test/modules/reportr/intervalLocationServiceSpec.js
+++ b/test/modules/reportr/intervalLocationServiceSpec.js
@@ -1,0 +1,47 @@
+define(['modules/reportr/intervalLocationService', 'moment'], function(IntervalLocationServiceCtor, moment) {
+    'use strict';
+    describe('The intervalLocationService', function() {
+        var locationMock, intervalLocationService;
+
+        beforeEach(function() {
+            locationMock = {
+                search: function() {                }
+            };
+            intervalLocationService = new IntervalLocationServiceCtor(locationMock);
+        });
+
+        it('must load the start and end date from the location if present', function() {
+            spyOn(locationMock, 'search').andReturn({
+                start: '2015-05-20',
+                end: '2015-05-21'
+            });
+            var interval = intervalLocationService.loadIntervalFromLocation();
+            expect(interval.start.getTime()).toBe(moment('2015-05-20').toDate().getTime());
+            expect(interval.end.getTime()).toBe(moment('2015-05-21').toDate().getTime());
+        });
+
+        it('must use the current month as the interval when the parameters are not present', function() {
+            spyOn(locationMock, 'search').andReturn({});
+            var interval = intervalLocationService.loadIntervalFromLocation();
+            expect(interval.start.getTime()).toBe(moment().startOf('month').toDate().getTime());
+            expect(interval.end.getTime()).toBe(moment().endOf('month').toDate().getTime());
+        });
+
+        it('must use the current month as the interval when the parameters are not strings', function() {
+            spyOn(locationMock, 'search').andReturn({
+                start: true,
+                end: true
+            });
+            var interval = intervalLocationService.loadIntervalFromLocation();
+            expect(interval.start.getTime()).toBe(moment().startOf('month').toDate().getTime());
+            expect(interval.end.getTime()).toBe(moment().endOf('month').toDate().getTime());
+        });
+
+        it('must set the location parameters', function() {
+            spyOn(locationMock, 'search');
+            intervalLocationService.saveIntervalToLocation(moment('2015-05-20'), moment('2015-05-21'));
+            expect(locationMock.search).toHaveBeenCalledWith('start', '2015-05-20');
+            expect(locationMock.search).toHaveBeenCalledWith('end', '2015-05-21');
+        });
+    });
+});


### PR DESCRIPTION
This PR modifies reportr so that all controllers update the URL when changing an interval in the report. This allows sharing specific reports via the URL. Also developers can easily reload reports without having to select the interval again every time.

I also switched the require.js injection to relative paths (saves some screenspace and even bytes) and the AngularJS injection to work via the .$inject property which is also great for saving some screenspace and still works with minification.