### PR TITLE
Bugfix: Show project after creation in trackr/administration

### DIFF
--- a/src/modules/trackr/administration/projects/listController.js
+++ b/src/modules/trackr/administration/projects/listController.js
@@ -17,7 +17,7 @@ define(['modules/shared/PaginationLoader'], function(PaginationLoader) {
                 'PROJECT.CREATE_NEW');
             $modalInstance.result.then(function(project) {
                 paginationLoader.loadPage();
-                $state.go('trackr.administration.projects.edit', {id: project.identifier});
+                $state.go('app.trackr.administration.projects.edit', {id: project.identifier});
             });
         };
     }];


### PR DESCRIPTION
Fixed a bug where trackr would not redirect to a created project on s…uccess.

The name of the state was missing the leading "app.".