### PR TITLE
trackr-272 - Mark expenses as paid

### DIFF
--- a/src/modules/trackr/employee/controllers.js
+++ b/src/modules/trackr/employee/controllers.js
@@ -6,18 +6,12 @@ define(
         './timesheet/timesheetOverviewController',
         './vacation/listController',
         './vacation/newController',
-        './expenses/listController',
-        './expenses/editController',
-        './expenses/expenseEditController',
-        './expenses/expenseNewController',
-        './expenses/reportNewController',
         './address_book/addressBookController',
         './sick_days/sickDaysController',
         './sick_days/sickDaysEditController'
     ],
     function(SelfController, SelfEditController, TimeSheetController, TimesheetOverviewController, VacationListController,
-             VacationNewController, ExpenseReportListController, ExpenseReportEditController, ExpensesEditController, ExpensesNewController,
-             ReportNewController, AddressBookController, SickDaysController, SickDaysEditController) {
+             VacationNewController, AddressBookController, SickDaysController, SickDaysEditController) {
         'use strict';
         return {
             init: function(module) {
@@ -27,11 +21,6 @@ define(
                 module.controller('trackr.employee.controllers.timesheet-overview', TimesheetOverviewController);
                 module.controller('trackr.employee.controllers.vacation-list', VacationListController);
                 module.controller('trackr.employee.controllers.vacation-new', VacationNewController);
-                module.controller('trackr.employee.controllers.expenseReport-list', ExpenseReportListController);
-                module.controller('trackr.employee.controllers.expenseReport-edit', ExpenseReportEditController);
-                module.controller('trackr.employee.controllers.expense-edit', ExpensesEditController);
-                module.controller('trackr.employee.controllers.expense-new', ExpensesNewController);
-                module.controller('trackr.employee.controllers.expenseReport-new', ReportNewController);
                 module.controller('trackr.employee.controllers.address_book', AddressBookController);
                 module.controller('trackr.employee.controllers.sick-days', SickDaysController);
                 module.controller('trackr.employee.controllers.sick-days-edit', SickDaysEditController);

--- a/src/modules/trackr/employee/controllers.js
+++ b/src/modules/trackr/employee/controllers.js
@@ -1,22 +1,23 @@
 define(
     [
-        'modules/trackr/employee/selfController',
-        'modules/trackr/employee/selfEditController',
-        'modules/trackr/employee/timesheet/timesheetController',
-        'modules/trackr/employee/timesheet/timesheetOverviewController',
-        'modules/trackr/employee/vacation/listController',
-        'modules/trackr/employee/vacation/newController',
-        'modules/trackr/employee/expenses/listController',
-        'modules/trackr/employee/expenses/editController',
-        'modules/trackr/employee/expenses/expenseEditController',
-        'modules/trackr/employee/expenses/reportNewController',
-        'modules/trackr/employee/address_book/addressBookController',
-        'modules/trackr/employee/sick_days/sickDaysController',
-        'modules/trackr/employee/sick_days/sickDaysEditController'
+        './selfController',
+        './selfEditController',
+        './timesheet/timesheetController',
+        './timesheet/timesheetOverviewController',
+        './vacation/listController',
+        './vacation/newController',
+        './expenses/listController',
+        './expenses/editController',
+        './expenses/expenseEditController',
+        './expenses/expenseNewController',
+        './expenses/reportNewController',
+        './address_book/addressBookController',
+        './sick_days/sickDaysController',
+        './sick_days/sickDaysEditController'
     ],
     function(SelfController, SelfEditController, TimeSheetController, TimesheetOverviewController, VacationListController,
-             VacationNewController, ExpenseReportListController, ExpenseReportEditController, ExpensesEditController, ReportNewController,
-             AddressBookController, SickDaysController, SickDaysEditController) {
+             VacationNewController, ExpenseReportListController, ExpenseReportEditController, ExpensesEditController, ExpensesNewController,
+             ReportNewController, AddressBookController, SickDaysController, SickDaysEditController) {
         'use strict';
         return {
             init: function(module) {
@@ -29,6 +30,7 @@ define(
                 module.controller('trackr.employee.controllers.expenseReport-list', ExpenseReportListController);
                 module.controller('trackr.employee.controllers.expenseReport-edit', ExpenseReportEditController);
                 module.controller('trackr.employee.controllers.expense-edit', ExpensesEditController);
+                module.controller('trackr.employee.controllers.expense-new', ExpensesNewController);
                 module.controller('trackr.employee.controllers.expenseReport-new', ReportNewController);
                 module.controller('trackr.employee.controllers.address_book', AddressBookController);
                 module.controller('trackr.employee.controllers.sick-days', SickDaysController);

--- a/src/modules/trackr/employee/employeeModule.js
+++ b/src/modules/trackr/employee/employeeModule.js
@@ -1,6 +1,6 @@
-define(['angular', 'modules/trackr/employee/controllers', 'moment'], function(angular, controllers, moment) {
+define(['angular', './controllers', 'moment', './expenses/employeeExpensesModule'], function(angular, controllers, moment) {
     'use strict';
-    var employee = angular.module('trackr.employee', []);
+    var employee = angular.module('trackr.employee', ['trackr.employee.expenses']);
     employee.config(['$stateProvider', function($stateProvider) {
         $stateProvider
             .state('app.trackr.employee', {
@@ -65,31 +65,6 @@ define(['angular', 'modules/trackr/employee/controllers', 'moment'], function(an
                     'new@app.trackr.employee.vacation': {
                         templateUrl: 'src/modules/trackr/employee/vacation/new.tpl.html',
                         controller: 'trackr.employee.controllers.vacation-new'
-                    }
-                }
-            })
-            .state('app.trackr.employee.expenses', {
-                url: '/expenses',
-                breadcrumbTranslateCode: 'PAGES.EMPLOYEE.EXPENSES.TITLE',
-                views: {
-                    'center@app': {
-                        templateUrl: 'src/modules/trackr/employee/expenses/list.tpl.html',
-                        controller: 'trackr.employee.controllers.expenseReport-list'
-                    }
-                }
-            })
-            .state('app.trackr.employee.expenses.edit', {
-                url: '/{id:\\d+}',
-                breadcrumbTranslateCode: 'ACTIONS.EDIT',
-                resolve: {
-                    expenseTypes: ['trackr.services.travelExpense', function(TravelExpenseService) {
-                        return TravelExpenseService.getTypes();
-                    }]
-                },
-                views: {
-                    'center@app': {
-                        templateUrl: 'src/modules/trackr/employee/expenses/edit.tpl.html',
-                        controller: 'trackr.employee.controllers.expenseReport-edit'
                     }
                 }
             })

--- a/src/modules/trackr/employee/expenses/edit.tpl.html
+++ b/src/modules/trackr/employee/expenses/edit.tpl.html
@@ -35,9 +35,9 @@
                 </td>
             </tr>
             <tr>
-                <td colspan="4"></td>
-                <td><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{totalCost | currency:'€'}}</b></td>
                 <td colspan="3"></td>
+                <td colspan="2"><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{totalCost | currency:'€'}}</b></td>
+                <td colspan="3"><span translate="PAGES.EMPLOYEE.EXPENSES.REIMBURSEMENT"></span>: <b>{{totalReimbursement | currency:'€'}}</b></td>
             </tr>
         </table>
     </div>

--- a/src/modules/trackr/employee/expenses/edit.tpl.html
+++ b/src/modules/trackr/employee/expenses/edit.tpl.html
@@ -6,49 +6,16 @@
 <h5>{{ report.debitor.name }} <span ng-show="report.project"> - {{report.project.name}}</span></h5>
 <div class="row">
     <div class="col-md-8">
-        <table class="table table-striped">
-            <tr>
-                <th translate="TRAVEL_EXPENSE.TYPE"></th>
-                <th translate="TRAVEL_EXPENSE.FROM_DATE"></th>
-                <th translate="TRAVEL_EXPENSE.TO_DATE"></th>
-                <th translate="TRAVEL_EXPENSE.VAT"></th>
-                <th translate="TRAVEL_EXPENSE.COST"></th>
-                <th translate="TRAVEL_EXPENSE.COMMENT"></th>
-                <th translate="TRAVEL_EXPENSE.PAID"></th>
-                <th translate="ACTIONS.ACTIONS"></th>
-            </tr>
-            <tr ng-repeat="expense in report.expenses">
-                <td translate="{{ 'TRAVEL_EXPENSE.TYPE_VALUES.' + expense.type }}"></td>
-                <td>{{ expense.fromDate | date:'dd.MM.yyyy'}}</td>
-                <td>{{ expense.toDate | date:'dd.MM.yyyy'}}</td>
-                <td>{{ expense.vat }} %</td>
-                <td>{{ expense.cost | currency:'€'}}</td>
-                <td>{{ expense.comment }}</td>
-                <td><span class="glyphicon glyphicon-ok" ng-show="expense.paid"></span></td>
-                <td>
-                    <button class="btn btn-sm btn-default" ng-show="editable(report)" ng-click="showEditForm(expense)">
-                        <span class="glyphicon glyphicon-pencil"></span>
-                    </button>
-                    <button class="btn btn-sm btn-default" ng-show="editable(report)" ng-click="removeExpense(expense)">
-                        <span class="glyphicon glyphicon-trash"></span>
-                    </button>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="3"></td>
-                <td colspan="2"><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{totalCost | currency:'€'}}</b></td>
-                <td colspan="3"><span translate="PAGES.EMPLOYEE.EXPENSES.REIMBURSEMENT"></span>: <b>{{totalReimbursement | currency:'€'}}</b></td>
-            </tr>
-        </table>
+        <employee-expenses-table expenses="report.expenses" editable="editable(report)"/>
     </div>
-    <div ng-if="editable(report)" ng-controller="trackr.employee.controllers.expense-new" class="col-md-4">
+    <div ng-if="editable(report)" ng-controller="trackr.employee.expenses.expenseNewController" class="col-md-4">
         <div ng-include="'src/modules/trackr/employee/expenses/expense-edit.tpl.html'"></div>
         <button type="submit" class="btn btn-primary" translate="ACTIONS.ADD" ng-click="addNewExpense(report)"></button>
     </div>
 </div>
 
-<button type="button" ng-click="submitReport(report)" class="btn btn-primary" translate="ACTIONS.SUBMIT"></button>
-<button type="button" ng-click="deleteReport(report)" class="btn btn-danger" translate="ACTIONS.REMOVE"></button>
+<button ng-if="editable(report)" type="button" ng-click="submitReport(report)" class="btn btn-primary" translate="ACTIONS.SUBMIT"></button>
+<button ng-if="deletable(report)" type="button" ng-click="deleteReport(report)" class="btn btn-danger" translate="ACTIONS.REMOVE"></button>
 
 <div class="space-md"></div>
 <comment-section comments="report.comments" preprocessor="addReport" url="travelExpenseReportComments"></comment-section>

--- a/src/modules/trackr/employee/expenses/edit.tpl.html
+++ b/src/modules/trackr/employee/expenses/edit.tpl.html
@@ -4,18 +4,22 @@
 <span class="pull-right"><a href ui-sref="app.trackr.employee.expenses" translate="ACTIONS.BACK"></a></span>
 <h4>{{ 'TRAVEL_EXPENSE_REPORT.' + report.status | translate }}</h4>
 <h5>{{ report.debitor.name }} <span ng-show="report.project"> - {{report.project.name}}</span></h5>
+
 <div class="row">
-    <div class="col-md-8">
-        <employee-expenses-table expenses="report.expenses" editable="editable(report)"/>
+    <employee-expenses-table expenses="report.expenses" editable="editable(report)"/>
+</div>
+
+<div class="row">
+    <div class="col-md-3">
+        <button ng-if="editable(report)" type="button" ng-click="submitReport(report)" class="btn btn-primary" translate="ACTIONS.SUBMIT"></button>
+        <button ng-if="deletable(report)" type="button" ng-click="deleteReport(report)" class="btn btn-danger" translate="ACTIONS.REMOVE"></button>
     </div>
-    <div ng-if="editable(report)" ng-controller="trackr.employee.expenses.expenseNewController" class="col-md-4">
+    <div ng-if="editable(report)" ng-controller="trackr.employee.expenses.expenseNewController" class="col-md-9">
         <div ng-include="'src/modules/trackr/employee/expenses/expense-edit.tpl.html'"></div>
         <button type="submit" class="btn btn-primary" translate="ACTIONS.ADD" ng-click="addNewExpense(report)"></button>
     </div>
 </div>
 
-<button ng-if="editable(report)" type="button" ng-click="submitReport(report)" class="btn btn-primary" translate="ACTIONS.SUBMIT"></button>
-<button ng-if="deletable(report)" type="button" ng-click="deleteReport(report)" class="btn btn-danger" translate="ACTIONS.REMOVE"></button>
 
 <div class="space-md"></div>
 <comment-section comments="report.comments" preprocessor="addReport" url="travelExpenseReportComments"></comment-section>

--- a/src/modules/trackr/employee/expenses/edit.tpl.html
+++ b/src/modules/trackr/employee/expenses/edit.tpl.html
@@ -4,61 +4,51 @@
 <span class="pull-right"><a href ui-sref="app.trackr.employee.expenses" translate="ACTIONS.BACK"></a></span>
 <h4>{{ 'TRAVEL_EXPENSE_REPORT.' + report.status | translate }}</h4>
 <h5>{{ report.debitor.name }} <span ng-show="report.project"> - {{report.project.name}}</span></h5>
-<table class="table table-striped">
-    <tr>
-        <th translate="TRAVEL_EXPENSE.TYPE"></th>
-        <th translate="TRAVEL_EXPENSE.FROM_DATE"></th>
-        <th translate="TRAVEL_EXPENSE.TO_DATE"></th>
-        <th translate="TRAVEL_EXPENSE.VAT"></th>
-        <th translate="TRAVEL_EXPENSE.COST"></th>
-        <th translate="TRAVEL_EXPENSE.COMMENT"></th>
-        <th translate="TRAVEL_EXPENSE.SUBMITTED"></th>
-        <th translate="ACTIONS.ACTIONS"></th>
-    </tr>
-    <tr ng-repeat="expense in report.expenses">
-        <td translate="{{ 'TRAVEL_EXPENSE.TYPE_VALUES.' + expense.type }}"></td>
-        <td>{{ expense.fromDate | date:'dd.MM.yyyy'}}</td>
-        <td>{{ expense.toDate | date:'dd.MM.yyyy'}}</td>
-        <td>{{ expense.vat }} %</td>
-        <td>{{ expense.cost | currency:'€'}}</td>
-        <td>{{expense.comment}}</td>
-        <td>{{ expense.submissionDate | date:'dd.MM.yyyy HH:mm:ss' }}</td>
-        <td>
-            <button class="btn btn-sm btn-default" ng-show="editable(report)" ng-click="showEditForm(expense)">
-                <span class="glyphicon glyphicon-pencil"></span>
-            </button>
-            <button class="btn btn-sm btn-default" ng-show="editable(report)" ng-click="removeExpense(expense)">
-                <span class="glyphicon glyphicon-trash"></span>
-            </button>
-        </td>
-    </tr>
-    <tr>
-        <td colspan="4"></td>
-        <td><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{totalCost | currency:'€'}}</b></td>
-        <td colspan="3"></td>
-    </tr>
-</table>
-
-<button ng-if="editable(report)" type="button" ng-click="submitReport(report)" class="btn btn-primary" translate="ACTIONS.SUBMIT"></button>
-<button ng-if="deletable(report)" type="button" ng-click="deleteReport(report)" class="btn btn-danger" translate="ACTIONS.REMOVE"></button>
-
-<form ng-if="editable(report)" action="" class="form-inline" ng-submit="addNewExpense(expense, report)">
-    <div class="form-group" error-display="fromDate">
-        <inline-datepicker model="expense.fromDate"></inline-datepicker>
+<div class="row">
+    <div class="col-md-8">
+        <table class="table table-striped">
+            <tr>
+                <th translate="TRAVEL_EXPENSE.TYPE"></th>
+                <th translate="TRAVEL_EXPENSE.FROM_DATE"></th>
+                <th translate="TRAVEL_EXPENSE.TO_DATE"></th>
+                <th translate="TRAVEL_EXPENSE.VAT"></th>
+                <th translate="TRAVEL_EXPENSE.COST"></th>
+                <th translate="TRAVEL_EXPENSE.COMMENT"></th>
+                <th translate="TRAVEL_EXPENSE.PAID"></th>
+                <th translate="ACTIONS.ACTIONS"></th>
+            </tr>
+            <tr ng-repeat="expense in report.expenses">
+                <td translate="{{ 'TRAVEL_EXPENSE.TYPE_VALUES.' + expense.type }}"></td>
+                <td>{{ expense.fromDate | date:'dd.MM.yyyy'}}</td>
+                <td>{{ expense.toDate | date:'dd.MM.yyyy'}}</td>
+                <td>{{ expense.vat }} %</td>
+                <td>{{ expense.cost | currency:'€'}}</td>
+                <td>{{ expense.comment }}</td>
+                <td><span class="glyphicon glyphicon-ok" ng-show="expense.paid"></span></td>
+                <td>
+                    <button class="btn btn-sm btn-default" ng-show="editable(report)" ng-click="showEditForm(expense)">
+                        <span class="glyphicon glyphicon-pencil"></span>
+                    </button>
+                    <button class="btn btn-sm btn-default" ng-show="editable(report)" ng-click="removeExpense(expense)">
+                        <span class="glyphicon glyphicon-trash"></span>
+                    </button>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="4"></td>
+                <td><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{totalCost | currency:'€'}}</b></td>
+                <td colspan="3"></td>
+            </tr>
+        </table>
     </div>
-    <div class="form-group" error-display="toDate">
-        <inline-datepicker model="expense.toDate"></inline-datepicker>
+    <div ng-if="editable(report)" ng-controller="trackr.employee.controllers.expense-new" class="col-md-4">
+        <div ng-include="'src/modules/trackr/employee/expenses/expense-edit.tpl.html'"></div>
+        <button type="submit" class="btn btn-primary" translate="ACTIONS.ADD" ng-click="addNewExpense(report)"></button>
     </div>
+</div>
 
-    <div class="form-group" error-display="type">
-        <select ng-model="expense.type" ng-options="t as translateTravelExpenseType(t) for t in expenseTypes"></select>
-    </div>
-
-    <bs-text property-name="cost" translate-code="TRAVEL_EXPENSE.COST" path="expense.cost" inline="true"></bs-text>
-    <bs-text property-name="vat" translate-code="TRAVEL_EXPENSE.VAT" path="expense.vat" inline="true"></bs-text>
-    <bs-text property-name="comment" translate-code="TRAVEL_EXPENSE.COMMENT" path="expense.comment" inline="true"></bs-text>
-    <button type="submit" class="btn btn-primary" translate="ACTIONS.ADD"></button>
-</form>
+<button type="button" ng-click="submitReport(report)" class="btn btn-primary" translate="ACTIONS.SUBMIT"></button>
+<button type="button" ng-click="deleteReport(report)" class="btn btn-danger" translate="ACTIONS.REMOVE"></button>
 
 <div class="space-md"></div>
 <comment-section comments="report.comments" preprocessor="addReport" url="travelExpenseReportComments"></comment-section>

--- a/src/modules/trackr/employee/expenses/editController.js
+++ b/src/modules/trackr/employee/expenses/editController.js
@@ -1,9 +1,8 @@
 define(['./expensesDecorator'], function(expensesDecorator) {
     'use strict';
-    return ['$scope', 'Restangular', 'trackr.services.travelExpenseReport', 'expenseTypes',
-        '$filter', '$stateParams', '$state', 'base.services.notification',
-        function($scope, Restangular, TravelExpenseReportService, expenseTypes, $filter, $stateParams, $state,
-                 NotificationService) {
+    return ['$scope', 'Restangular', 'trackr.services.travelExpenseReport', '$filter', '$stateParams', '$state',
+        'base.services.notification',
+        function($scope, Restangular, TravelExpenseReportService, $filter, $stateParams, $state, NotificationService) {
 
             Restangular.one('travelExpenseReports', $stateParams.id).get({
                 projection: 'withExpensesAndDebitorAndProject'
@@ -22,7 +21,6 @@ define(['./expensesDecorator'], function(expensesDecorator) {
                     $scope.report.statusTranslateCode = 'TRAVEL_EXPENSE_REPORT.' + report.status;
                 });
 
-            $scope.expenseTypes = expenseTypes;
             $scope.comment = {};
             $scope.errors = [];
 

--- a/src/modules/trackr/employee/expenses/editController.js
+++ b/src/modules/trackr/employee/expenses/editController.js
@@ -35,7 +35,6 @@ define(['lodash'], function(_) {
                 });
 
             $scope.expenseTypes = expenseTypes;
-            $scope.expense = {};
             $scope.comment = {};
             $scope.errors = [];
 
@@ -93,28 +92,6 @@ define(['lodash'], function(_) {
             };
 
             /**
-             * Add a new expense to the report. Calls the backend.
-             *
-             * Will automatically set the submission date and report ref.
-             *
-             * Will add the cost of the expense to the totalCost scope variable.
-             * @param expense The expense to add.
-             * @param report The report to add the expense to.
-             */
-            $scope.addNewExpense = function(expense, report) {
-                expense.report = report._links.self.href;
-                expense.submissionDate = new Date();
-                Restangular.all('travelExpenses').post(expense).then(function(expense) {
-                    report.expenses.push(expense);
-                    $scope.totalCost = $scope.totalCost + parseFloat(expense.cost);
-                    $scope.errors = [];
-                    $scope.expense = {};
-                }, function(response) {
-                    $scope.errors = response.data.errors;
-                });
-            };
-
-            /**
              * Sets the status of the report to submitted.
              * @param travelExpenseReport
              */
@@ -157,5 +134,11 @@ define(['lodash'], function(_) {
                 comment.travelExpenseReport = $scope.report._links.self.href;
                 return comment;
             };
+
+            $scope.$on('newExpense', function(event, expense) {
+                event.stopPropagation();
+                $scope.report.expenses.push(expense);
+                $scope.totalCost = $scope.totalCost + parseFloat(expense.cost);
+            });
         }];
 });

--- a/src/modules/trackr/employee/expenses/editController.js
+++ b/src/modules/trackr/employee/expenses/editController.js
@@ -17,6 +17,12 @@ define(['lodash'], function(_) {
                 }, 0);
             };
 
+            controller.recalculateTotalReimbursement = function(expenses) {
+                return expenses.reduce(function(prev, expense) {
+                    return prev + (expense.paid === true ? 0 : parseFloat(expense.cost));
+                }, 0);
+            };
+
             Restangular.one('travelExpenseReports', $stateParams.id).get({
                 projection: 'withExpensesAndDebitorAndProject'
             })
@@ -32,6 +38,7 @@ define(['lodash'], function(_) {
                     $scope.report = report;
                     $scope.report.statusTranslateCode = 'TRAVEL_EXPENSE_REPORT.' + report.status;
                     $scope.totalCost = controller.recalculateTotal(report.expenses);
+                    $scope.totalReimbursement = controller.recalculateTotalReimbursement(report.expenses);
                 });
 
             $scope.expenseTypes = expenseTypes;
@@ -65,6 +72,7 @@ define(['lodash'], function(_) {
                     Restangular.one('travelExpenses', expense.id).remove().then(function() {
                         _.remove($scope.report.expenses, {id: expense.id});
                         $scope.totalCost = controller.recalculateTotal($scope.report.expenses);
+                        $scope.totalReimbursement = controller.recalculateTotalReimbursement($scope.report.expenses);
                     });
                 }
 
@@ -88,6 +96,7 @@ define(['lodash'], function(_) {
                     var index = _.findIndex($scope.report.expenses, {id: editedExpense.id });
                     $scope.report.expenses[index] = editedExpense;
                     $scope.totalCost = controller.recalculateTotal($scope.report.expenses);
+                    $scope.totalReimbursement = controller.recalculateTotalReimbursement($scope.report.expenses);
                 });
             };
 
@@ -119,15 +128,6 @@ define(['lodash'], function(_) {
             };
 
             /**
-             * Translate the travel expense type from its enum value.
-             * @param type The enum value (e.g. TAXI)
-             * @returns {*} The translation (e.g. Taxi)
-             */
-            $scope.translateTravelExpenseType = function(type) {
-                return $filter('translate')('TRAVEL_EXPENSE.TYPE_VALUES.' + type);
-            };
-
-            /**
              * Preprocessor for comment-section.
              */
             $scope.addReport = function(comment) {
@@ -139,6 +139,9 @@ define(['lodash'], function(_) {
                 event.stopPropagation();
                 $scope.report.expenses.push(expense);
                 $scope.totalCost = $scope.totalCost + parseFloat(expense.cost);
+                if(expense.paid === false) {
+                    $scope.totalReimbursement = $scope.totalReimbursement + parseFloat(expense.cost);
+                }
             });
         }];
 });

--- a/src/modules/trackr/employee/expenses/editController.js
+++ b/src/modules/trackr/employee/expenses/editController.js
@@ -1,4 +1,4 @@
-define([], function() {
+define(['./expensesDecorator'], function(expensesDecorator) {
     'use strict';
     return ['$scope', 'Restangular', 'trackr.services.travelExpenseReport', 'expenseTypes',
         '$filter', '$stateParams', '$state', 'base.services.notification',
@@ -18,6 +18,7 @@ define([], function() {
                 })
                 .then(function(report) {
                     $scope.report = report;
+                    expensesDecorator($scope.report.expenses);
                     $scope.report.statusTranslateCode = 'TRAVEL_EXPENSE_REPORT.' + report.status;
                 });
 

--- a/src/modules/trackr/employee/expenses/editController.js
+++ b/src/modules/trackr/employee/expenses/editController.js
@@ -1,27 +1,9 @@
-define(['lodash'], function(_) {
+define([], function() {
     'use strict';
     return ['$scope', 'Restangular', 'trackr.services.travelExpenseReport', 'expenseTypes',
-        '$filter', 'base.services.confirmation-dialog', '$stateParams', 'shared.services.create-or-update-modal', '$state',
-        'base.services.notification',
-        function($scope, Restangular, TravelExpenseReportService, expenseTypes, $filter, ConfirmationDialogService, $stateParams, createOrUpdateModalService, $state,
+        '$filter', '$stateParams', '$state', 'base.services.notification',
+        function($scope, Restangular, TravelExpenseReportService, expenseTypes, $filter, $stateParams, $state,
                  NotificationService) {
-            var controller = this;
-            /**
-             * Recalculate the sum of the cost of the expenses
-             * @param  expenses An array of expenses, each must have the property "cost".
-             * @return The sum of all costs.
-             */
-            controller.recalculateTotal = function(expenses) {
-                return expenses.reduce(function(prev, expense) {
-                    return prev + parseFloat(expense.cost);
-                }, 0);
-            };
-
-            controller.recalculateTotalReimbursement = function(expenses) {
-                return expenses.reduce(function(prev, expense) {
-                    return prev + (expense.paid === true ? 0 : parseFloat(expense.cost));
-                }, 0);
-            };
 
             Restangular.one('travelExpenseReports', $stateParams.id).get({
                 projection: 'withExpensesAndDebitorAndProject'
@@ -37,8 +19,6 @@ define(['lodash'], function(_) {
                 .then(function(report) {
                     $scope.report = report;
                     $scope.report.statusTranslateCode = 'TRAVEL_EXPENSE_REPORT.' + report.status;
-                    $scope.totalCost = controller.recalculateTotal(report.expenses);
-                    $scope.totalReimbursement = controller.recalculateTotalReimbursement(report.expenses);
                 });
 
             $scope.expenseTypes = expenseTypes;
@@ -61,43 +41,6 @@ define(['lodash'], function(_) {
              */
             $scope.deletable = function(report) {
                 return report !== undefined && (report.status === 'PENDING' || report.status === 'REJECTED');
-            };
-
-            /**
-             * Remove an expense from the report. Calls the backend.
-             * @param expense The expense to remove.
-             */
-            $scope.removeExpense = function(expense) {
-                function deleteExpense() {
-                    Restangular.one('travelExpenses', expense.id).remove().then(function() {
-                        _.remove($scope.report.expenses, {id: expense.id});
-                        $scope.totalCost = controller.recalculateTotal($scope.report.expenses);
-                        $scope.totalReimbursement = controller.recalculateTotalReimbursement($scope.report.expenses);
-                    });
-                }
-
-                ConfirmationDialogService.openConfirmationDialog('ACTIONS.REALLY_DELETE').result.then(deleteExpense);
-            };
-
-            /**
-             * Opens the edit form for a single expense and updates the list if the user edited the expense.
-             * @param expense
-             */
-            $scope.showEditForm = function(expense) {
-                var $modalInstance = createOrUpdateModalService
-                    .showModal('trackr.employee.controllers.expense-edit as ctrl',
-                    'src/modules/trackr/employee/expenses/expense-edit.tpl.html',
-                    'ACTIONS.EDIT', {
-                        expense: expense,
-                        expenseTypes: $scope.expenseTypes
-                    });
-
-                $modalInstance.result.then(function(editedExpense) {
-                    var index = _.findIndex($scope.report.expenses, {id: editedExpense.id });
-                    $scope.report.expenses[index] = editedExpense;
-                    $scope.totalCost = controller.recalculateTotal($scope.report.expenses);
-                    $scope.totalReimbursement = controller.recalculateTotalReimbursement($scope.report.expenses);
-                });
             };
 
             /**
@@ -136,12 +79,7 @@ define(['lodash'], function(_) {
             };
 
             $scope.$on('newExpense', function(event, expense) {
-                event.stopPropagation();
                 $scope.report.expenses.push(expense);
-                $scope.totalCost = $scope.totalCost + parseFloat(expense.cost);
-                if(expense.paid === false) {
-                    $scope.totalReimbursement = $scope.totalReimbursement + parseFloat(expense.cost);
-                }
             });
         }];
 });

--- a/src/modules/trackr/employee/expenses/employeeExpensesModule.js
+++ b/src/modules/trackr/employee/expenses/employeeExpensesModule.js
@@ -1,0 +1,46 @@
+define(['angular', './listController', './editController', './expenseEditController', './expenseNewController',
+        './reportNewController', './expensesTableDirective', './expensesTableController'],
+    function(angular, ListController, EditController, ExpenseEditController, ExpenseNewController, ReportNewController,
+        ExpensesTableDirective, ExpensesTableController) {
+        'use strict';
+        function config($stateProvider) {
+            $stateProvider
+                .state('app.trackr.employee.expenses', {
+                    url: '/expenses',
+                    breadcrumbTranslateCode: 'PAGES.EMPLOYEE.EXPENSES.TITLE',
+                    views: {
+                        'center@app': {
+                            templateUrl: 'src/modules/trackr/employee/expenses/list.tpl.html',
+                            controller: 'trackr.employee.expenses.expenseReportListController'
+                        }
+                    }
+                })
+                .state('app.trackr.employee.expenses.edit', {
+                    url: '/{id:\\d+}',
+                    breadcrumbTranslateCode: 'ACTIONS.EDIT',
+                    resolve: {
+                        expenseTypes: ['trackr.services.travelExpense', function(TravelExpenseService) {
+                            return TravelExpenseService.getTypes();
+                        }]
+                    },
+                    views: {
+                        'center@app': {
+                            templateUrl: 'src/modules/trackr/employee/expenses/edit.tpl.html',
+                            controller: 'trackr.employee.expenses.expenseReportEditController'
+                        }
+                    }
+                });
+        }
+        config.$inject = ['$stateProvider'];
+
+        var module = angular.module('trackr.employee.expenses', [], config);
+        module.controller('trackr.employee.expenses.expenseReportListController', ListController);
+        module.controller('trackr.employee.expenses.expenseReportEditController', EditController);
+        module.controller('trackr.employee.expenses.expenseEditController', ExpenseEditController);
+        module.controller('trackr.employee.expenses.expenseNewController', ExpenseNewController);
+        module.controller('trackr.employee.expenses.expenseReportNewController', ReportNewController);
+
+        module.directive('employeeExpensesTable', ExpensesTableDirective);
+        module.controller('trackr.employee.expenses.expenseTableController', ExpensesTableController);
+        return module;
+    });

--- a/src/modules/trackr/employee/expenses/employeeExpensesModule.js
+++ b/src/modules/trackr/employee/expenses/employeeExpensesModule.js
@@ -20,7 +20,7 @@ define(['angular', './listController', './editController', './expenseEditControl
                     breadcrumbTranslateCode: 'ACTIONS.EDIT',
                     resolve: {
                         expenseTypes: ['trackr.services.travelExpense', function(TravelExpenseService) {
-                            return TravelExpenseService.getTypes();
+                            return TravelExpenseService.loadTypes();
                         }]
                     },
                     views: {

--- a/src/modules/trackr/employee/expenses/expense-edit.tpl.html
+++ b/src/modules/trackr/employee/expenses/expense-edit.tpl.html
@@ -1,6 +1,6 @@
 <form class="form-horizontal">
     <div class="form-group" error-display="type">
-        <label class="form-label col-sm-4" for="type" translate="TRAVEL_EXPENSE.TYPE"></label>
+        <label class="form-label col-sm-2" for="type" translate="TRAVEL_EXPENSE.TYPE"></label>
         <div class="col-sm-6">
             <select ng-model="expense.type" id="type" ng-options="t as translateTravelExpenseType(t) for t in expenseTypes"></select>
         </div>
@@ -48,4 +48,14 @@
     </div>
 
     <bs-text property-name="comment" translate-code="TRAVEL_EXPENSE.COMMENT" path="expense.comment"></bs-text>
+
+    <div class="form-group">
+        <div class="col-sm-offset-2 col-sm-10">
+            <div class="checkbox">
+                <label>
+                    <input type="checkbox" ng-model="expense.paid"> <span translate="TRAVEL_EXPENSE.PAID"></span>
+                </label>
+            </div>
+        </div>
+    </div>
 </form>

--- a/src/modules/trackr/employee/expenses/expenseEditController.js
+++ b/src/modules/trackr/employee/expenses/expenseEditController.js
@@ -1,6 +1,7 @@
 define(['lodash'], function(_) {
     'use strict';
     function expenseEditController(userdata, TravelExpenseService, $scope, Restangular, $filter) {
+        /*jshint validthis:true */
         var controller = this;
         $scope.expense = _.clone(userdata.expense, false);
         $scope.expenseTypes = TravelExpenseService.getTypes();

--- a/src/modules/trackr/employee/expenses/expenseEditController.js
+++ b/src/modules/trackr/employee/expenses/expenseEditController.js
@@ -1,12 +1,9 @@
 define(['lodash'], function(_) {
     'use strict';
-    /**
-     * Controller to watch editing of some fields of a single expense in a report.
-     */
-    return ['createOrUpdateModal.userdata', '$scope', 'Restangular', '$filter', function(userdata, $scope, Restangular, $filter) {
+    function expenseEditController(userdata, TravelExpenseService, $scope, Restangular, $filter) {
         var controller = this;
         $scope.expense = _.clone(userdata.expense, false);
-        $scope.expenseTypes = userdata.expenseTypes;
+        $scope.expenseTypes = TravelExpenseService.getTypes();
 
         controller.onFail = function(response) {
             $scope.errors = response.data.errors;
@@ -43,5 +40,7 @@ define(['lodash'], function(_) {
             'year-format': '\'yyyy\'',
             'starting-day': 1
         };
-    }];
+    }
+    expenseEditController.$inject = ['createOrUpdateModal.userdata', 'trackr.services.travelExpense', '$scope', 'Restangular', '$filter'];
+    return expenseEditController;
 });

--- a/src/modules/trackr/employee/expenses/expenseEditController.js
+++ b/src/modules/trackr/employee/expenses/expenseEditController.js
@@ -13,7 +13,7 @@ define(['lodash'], function(_) {
         };
 
         controller.saveExpense = function(expense) {
-            var expenseEntity = _.pick(expense, ['id', 'version', 'type', 'fromDate', 'toDate', 'vat', 'cost', 'comment']);
+            var expenseEntity = _.pick(expense, ['id', 'version', 'type', 'fromDate', 'toDate', 'vat', 'cost', 'comment', 'paid']);
             Restangular.one('travelExpenses', expenseEntity.id).patch(expenseEntity)
                 .then(function(result) {
                     $scope.closeModal(result);

--- a/src/modules/trackr/employee/expenses/expenseNewController.js
+++ b/src/modules/trackr/employee/expenses/expenseNewController.js
@@ -1,11 +1,12 @@
 define([], function () {
     'use strict';
 
-    var expenseNewController = function($scope, Restangular, $filter) {
+    var expenseNewController = function($scope, Restangular, $filter, TravelExpenseService) {
         var controller = this;
 
         $scope.ctrl = this; // todo legacy because the included modal references it this way..
         $scope.expense = {};
+        $scope.expenseTypes = TravelExpenseService.getTypes();
 
         $scope.addNewExpense = function(report) {
             $scope.expense.report = report._links.self.href;
@@ -43,6 +44,6 @@ define([], function () {
         };
 
     };
-    expenseNewController.$inject = ['$scope', 'Restangular', '$filter'];
+    expenseNewController.$inject = ['$scope', 'Restangular', '$filter', 'trackr.services.travelExpense'];
     return expenseNewController;
 });

--- a/src/modules/trackr/employee/expenses/expenseNewController.js
+++ b/src/modules/trackr/employee/expenses/expenseNewController.js
@@ -1,0 +1,39 @@
+define([], function () {
+    'use strict';
+
+    var expenseNewController = function($scope, Restangular) {
+        var controller = this;
+
+        $scope.ctrl = this; // todo legacy because the included modal references it this way..
+        $scope.expense = {};
+
+        $scope.addNewExpense = function(report) {
+            $scope.expense.report = report._links.self.href;
+            $scope.expense.submissionDate = new Date();
+            Restangular.all('travelExpenses').post($scope.expense).then(function(expense) {
+                $scope.errors = [];
+                $scope.expense = {
+                    toDate: expense.toDate,
+                    fromDate: expense.fromDate
+                };
+                $scope.$emit('newExpense', expense);
+            }, function(response) {
+                $scope.errors = response.data.errors;
+            });
+        };
+
+        $scope.openDate = function($event, name) {
+            $event.stopPropagation();
+            $event.preventDefault();
+            controller[name] = true;
+        };
+
+        $scope.dateOptions = {
+            'year-format': '\'yyyy\'',
+            'starting-day': 1
+        };
+
+    };
+    expenseNewController.$inject = ['$scope', 'Restangular'];
+    return expenseNewController;
+});

--- a/src/modules/trackr/employee/expenses/expenseNewController.js
+++ b/src/modules/trackr/employee/expenses/expenseNewController.js
@@ -1,7 +1,7 @@
 define([], function () {
     'use strict';
 
-    var expenseNewController = function($scope, Restangular) {
+    var expenseNewController = function($scope, Restangular, $filter) {
         var controller = this;
 
         $scope.ctrl = this; // todo legacy because the included modal references it this way..
@@ -22,6 +22,15 @@ define([], function () {
             });
         };
 
+        /**
+         * Translate the travel expense type from its enum value.
+         * @param type The enum value (e.g. TAXI)
+         * @returns {*} The translation (e.g. Taxi)
+         */
+        $scope.translateTravelExpenseType = function(type) {
+            return $filter('translate')('TRAVEL_EXPENSE.TYPE_VALUES.' + type);
+        };
+
         $scope.openDate = function($event, name) {
             $event.stopPropagation();
             $event.preventDefault();
@@ -34,6 +43,6 @@ define([], function () {
         };
 
     };
-    expenseNewController.$inject = ['$scope', 'Restangular'];
+    expenseNewController.$inject = ['$scope', 'Restangular', '$filter'];
     return expenseNewController;
 });

--- a/src/modules/trackr/employee/expenses/expensesDecorator.js
+++ b/src/modules/trackr/employee/expenses/expensesDecorator.js
@@ -1,0 +1,31 @@
+define([], function() {
+    'use strict';
+
+    /**
+     * Add up the cost of all expenses.
+     * @returns {Number}
+     */
+    function totalCost() {
+        return this.reduce(function(prev, expense) {
+            return prev + parseFloat(expense.cost);
+        }, 0);
+    }
+
+    /**
+     * Add up the cost of all expenses that are not paid yet.
+     * @returns {Number}
+     */
+    function totalReimbursement() {
+        return this.reduce(function(prev, expense) {
+            return prev + (expense.paid ? 0 : parseFloat(expense.cost));
+        }, 0);
+    }
+
+    /**
+     * Decorate an expenses array with two methods to calculate the sum of costs and not-paid costs.
+     */
+    return function(expenses) {
+        expenses.totalCost = totalCost;
+        expenses.totalReimbursement = totalReimbursement;
+    };
+});

--- a/src/modules/trackr/employee/expenses/expensesDecorator.js
+++ b/src/modules/trackr/employee/expenses/expensesDecorator.js
@@ -6,6 +6,7 @@ define([], function() {
      * @returns {Number}
      */
     function totalCost() {
+        /*jshint validthis:true */
         return this.reduce(function(prev, expense) {
             return prev + parseFloat(expense.cost);
         }, 0);
@@ -16,6 +17,7 @@ define([], function() {
      * @returns {Number}
      */
     function totalReimbursement() {
+        /*jshint validthis:true */
         return this.reduce(function(prev, expense) {
             return prev + (expense.paid ? 0 : parseFloat(expense.cost));
         }, 0);

--- a/src/modules/trackr/employee/expenses/expensesTable.tpl.html
+++ b/src/modules/trackr/employee/expenses/expensesTable.tpl.html
@@ -1,0 +1,34 @@
+<table class="table table-striped">
+    <tr>
+        <th translate="TRAVEL_EXPENSE.TYPE"></th>
+        <th translate="TRAVEL_EXPENSE.FROM_DATE"></th>
+        <th translate="TRAVEL_EXPENSE.TO_DATE"></th>
+        <th translate="TRAVEL_EXPENSE.VAT"></th>
+        <th translate="TRAVEL_EXPENSE.COST"></th>
+        <th translate="TRAVEL_EXPENSE.COMMENT"></th>
+        <th translate="TRAVEL_EXPENSE.PAID"></th>
+        <th translate="ACTIONS.ACTIONS"></th>
+    </tr>
+    <tr ng-repeat="expense in expenses">
+        <td translate="{{ 'TRAVEL_EXPENSE.TYPE_VALUES.' + expense.type }}"></td>
+        <td>{{ expense.fromDate | date:'dd.MM.yyyy'}}</td>
+        <td>{{ expense.toDate | date:'dd.MM.yyyy'}}</td>
+        <td>{{ expense.vat }} %</td>
+        <td>{{ expense.cost | currency:'€'}}</td>
+        <td>{{ expense.comment }}</td>
+        <td><span class="glyphicon glyphicon-ok" ng-show="expense.paid"></span></td>
+        <td>
+            <button class="btn btn-sm btn-default" ng-show="editable" ng-click="showEditForm(expense)">
+                <span class="glyphicon glyphicon-pencil"></span>
+            </button>
+            <button class="btn btn-sm btn-default" ng-show="editable" ng-click="removeExpense(expense)">
+                <span class="glyphicon glyphicon-trash"></span>
+            </button>
+        </td>
+    </tr>
+    <tr>
+        <td colspan="3"></td>
+        <td colspan="2"><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{totalCost() | currency:'€'}}</b></td>
+        <td colspan="3"><span translate="PAGES.EMPLOYEE.EXPENSES.REIMBURSEMENT"></span>: <b>{{totalReimbursement() | currency:'€'}}</b></td>
+    </tr>
+</table>

--- a/src/modules/trackr/employee/expenses/expensesTable.tpl.html
+++ b/src/modules/trackr/employee/expenses/expensesTable.tpl.html
@@ -9,7 +9,7 @@
         <th translate="TRAVEL_EXPENSE.PAID"></th>
         <th translate="ACTIONS.ACTIONS"></th>
     </tr>
-    <tr ng-repeat="expense in expenses">
+    <tr ng-repeat="expense in expenses track by expense.id">
         <td translate="{{ 'TRAVEL_EXPENSE.TYPE_VALUES.' + expense.type }}"></td>
         <td>{{ expense.fromDate | date:'dd.MM.yyyy'}}</td>
         <td>{{ expense.toDate | date:'dd.MM.yyyy'}}</td>
@@ -28,7 +28,7 @@
     </tr>
     <tr>
         <td colspan="3"></td>
-        <td colspan="2"><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{totalCost() | currency:'€'}}</b></td>
-        <td colspan="3"><span translate="PAGES.EMPLOYEE.EXPENSES.REIMBURSEMENT"></span>: <b>{{totalReimbursement() | currency:'€'}}</b></td>
+        <td colspan="2"><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{expenses.totalCost() | currency:'€'}}</b></td>
+        <td colspan="3"><span translate="PAGES.EMPLOYEE.EXPENSES.REIMBURSEMENT"></span>: <b>{{expenses.totalReimbursement() | currency:'€'}}</b></td>
     </tr>
 </table>

--- a/src/modules/trackr/employee/expenses/expensesTableController.js
+++ b/src/modules/trackr/employee/expenses/expensesTableController.js
@@ -4,22 +4,6 @@ define(['lodash'], function(_) {
         $scope.expenses = [];
 
         /**
-         * Recalculate the sum of the cost of the expenses
-         * @return The sum of all costs.
-         */
-        $scope.totalCost = function() {
-            return $scope.expenses.reduce(function(prev, expense) {
-                return prev + parseFloat(expense.cost);
-            }, 0);
-        };
-
-        $scope.totalReimbursement = function() {
-            return $scope.expenses.reduce(function(prev, expense) {
-                return prev + (expense.paid === true ? 0 : parseFloat(expense.cost));
-            }, 0);
-        };
-
-        /**
          * Remove an expense from the report.
          * @param expense The expense to remove.
          */

--- a/src/modules/trackr/employee/expenses/expensesTableController.js
+++ b/src/modules/trackr/employee/expenses/expensesTableController.js
@@ -26,8 +26,7 @@ define(['lodash'], function(_) {
                 .showModal('trackr.employee.expenses.expenseEditController as ctrl',
                 'src/modules/trackr/employee/expenses/expense-edit.tpl.html',
                 'ACTIONS.EDIT', {
-                    expense: expense,
-                    expenseTypes: $scope.expenseTypes
+                    expense: expense
                 });
 
             $modalInstance.result.then(function(editedExpense) {

--- a/src/modules/trackr/employee/expenses/expensesTableController.js
+++ b/src/modules/trackr/employee/expenses/expensesTableController.js
@@ -1,0 +1,59 @@
+define(['lodash'], function(_) {
+    'use strict';
+    function expensesTableController($scope, Restangular, ConfirmationDialogService, createOrUpdateModalService) {
+        $scope.expenses = [];
+
+        /**
+         * Recalculate the sum of the cost of the expenses
+         * @return The sum of all costs.
+         */
+        $scope.totalCost = function() {
+            return $scope.expenses.reduce(function(prev, expense) {
+                return prev + parseFloat(expense.cost);
+            }, 0);
+        };
+
+        $scope.totalReimbursement = function() {
+            return $scope.expenses.reduce(function(prev, expense) {
+                return prev + (expense.paid === true ? 0 : parseFloat(expense.cost));
+            }, 0);
+        };
+
+        /**
+         * Remove an expense from the report.
+         * @param expense The expense to remove.
+         */
+        $scope.removeExpense = function(expense) {
+            function deleteExpense() {
+                Restangular.one('travelExpenses', expense.id).remove().then(function() {
+                    _.remove($scope.expenses, {id: expense.id});
+                });
+            }
+
+            ConfirmationDialogService.openConfirmationDialog('ACTIONS.REALLY_DELETE').result.then(deleteExpense);
+        };
+
+        /**
+         * Opens the edit form for a single expense and updates the list if the user edited the expense.
+         * @param expense
+         */
+        $scope.showEditForm = function(expense) {
+            var $modalInstance = createOrUpdateModalService
+                .showModal('trackr.employee.expenses.expenseEditController as ctrl',
+                'src/modules/trackr/employee/expenses/expense-edit.tpl.html',
+                'ACTIONS.EDIT', {
+                    expense: expense,
+                    expenseTypes: $scope.expenseTypes
+                });
+
+            $modalInstance.result.then(function(editedExpense) {
+                var index = _.findIndex($scope.expenses, {id: editedExpense.id });
+                $scope.expenses[index] = editedExpense;
+            });
+        };
+
+    }
+
+    expensesTableController.$inject = ['$scope', 'Restangular', 'base.services.confirmation-dialog', 'shared.services.create-or-update-modal'];
+    return expensesTableController;
+});

--- a/src/modules/trackr/employee/expenses/expensesTableDirective.js
+++ b/src/modules/trackr/employee/expenses/expensesTableDirective.js
@@ -1,0 +1,15 @@
+define([], function() {
+    'use strict';
+    var expensesTableDirective = function() {
+        return {
+            restrict: 'E',
+            scope: {
+                expenses: '=',
+                editable: '='
+            },
+            templateUrl: 'src/modules/trackr/employee/expenses/expensesTable.tpl.html',
+            controller: 'trackr.employee.expenses.expenseTableController'
+        };
+    };
+    return expensesTableDirective;
+});

--- a/src/modules/trackr/employee/expenses/list.tpl.html
+++ b/src/modules/trackr/employee/expenses/list.tpl.html
@@ -16,7 +16,7 @@
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="report in reports[state]">
+            <tr ng-repeat="report in reports[state] track by report.id">
                 <td><a ui-sref="app.trackr.employee.expenses.edit({id: report.id})">#{{report.id}}</a></td>
                 <td>{{ report.total | currency:'€' }}</td>
                 <td>{{ report.debitor.name }}</td>

--- a/src/modules/trackr/employee/expenses/listController.js
+++ b/src/modules/trackr/employee/expenses/listController.js
@@ -50,7 +50,7 @@ define(['modules/shared/PaginationLoader', 'lodash'], function(PaginationLoader,
          */
         $scope.addNew = function() {
             var $modalInstance = CreateOrUpdateModalService
-                .showModal('trackr.employee.controllers.expenseReport-new as ctrl',
+                .showModal('trackr.employee.expenses.expenseReportNewController as ctrl',
                 'src/modules/trackr/employee/expenses/report-new.tpl.html',
                 'TRAVEL_EXPENSE_REPORT.TRAVEL_EXPENSE_REPORT');
 

--- a/src/modules/trackr/services/travelExpenseService.js
+++ b/src/modules/trackr/services/travelExpenseService.js
@@ -1,11 +1,16 @@
 define([], function() {
     'use strict';
     return ['$http', function($http) {
+        var expenseTypes;
         return {
-            getTypes: function() {
+            loadTypes: function() {
                 return $http.get('api/travelExpenses/types').then(function(response) {
-                    return response.data;
+                    expenseTypes = response.data;
+                    return expenseTypes;
                 });
+            },
+            getTypes: function() {
+                return expenseTypes;
             }
         };
     }];

--- a/src/modules/trackr/supervisor/controllers.js
+++ b/src/modules/trackr/supervisor/controllers.js
@@ -1,14 +1,12 @@
 define(
     [
-        'modules/trackr/supervisor/fileBillableHoursController',
-        'modules/trackr/supervisor/fileBillableHoursSaveController',
-        'modules/trackr/supervisor/billReportController',
-        'modules/trackr/supervisor/vacation/vacationController',
-        'modules/trackr/supervisor/expenses/listController',
-        'modules/trackr/supervisor/expenses/editController'
+        './fileBillableHoursController',
+        './fileBillableHoursSaveController',
+        './billReportController',
+        './vacation/vacationController'
     ],
     function(FileBillableHoursController, FileBillableHoursSaveController, BillReportController,
-            VacationController, TravelExpenseReportListController, TravelExpenseReportEditController) {
+            VacationController) {
         'use strict';
         return {
             init: function(module) {
@@ -16,8 +14,6 @@ define(
                 module.controller('trackr.supervisor.controllers.save-billable-hours', FileBillableHoursSaveController);
                 module.controller('trackr.supervisor.controllers.bill-report', BillReportController);
                 module.controller('trackr.supervisor.controllers.vacation', VacationController);
-                module.controller('trackr.supervisor.controllers.expenseReport-list', TravelExpenseReportListController);
-                module.controller('trackr.supervisor.controllers.expenseReport-edit', TravelExpenseReportEditController);
             }
         };
     }

--- a/src/modules/trackr/supervisor/expenses/edit.tpl.html
+++ b/src/modules/trackr/supervisor/expenses/edit.tpl.html
@@ -35,21 +35,23 @@
         <th translate="TRAVEL_EXPENSE.VAT"></th>
         <th translate="TRAVEL_EXPENSE.COST"></th>
         <th translate="TRAVEL_EXPENSE.COMMENT"></th>
+        <th translate="TRAVEL_EXPENSE.PAID"></th>
         <th translate="TRAVEL_EXPENSE.SUBMITTED"></th>
     </tr>
-    <tr ng-repeat="expense in report.expenses">
+    <tr ng-repeat="expense in report.expenses track by expense.id">
         <td translate="{{expense.type}}"></td>
         <td>{{ expense.fromDate | date:'dd.MM.yyyy'}}</td>
         <td>{{ expense.toDate | date:'dd.MM.yyyy'}}</td>
         <td>{{ expense.vat }} %</td>
         <td>{{ expense.cost | currency:'€' }}</td>
         <td>{{expense.comment}}</td>
+        <td><span class="glyphicon glyphicon-ok" ng-show="expense.paid"></span></td>
         <td>{{ expense.submissionDate | date:'dd.MM.yyyy HH:mm:ss' }}</td>
     </tr>
     <tr>
-        <td colspan="4"></td>
-        <td><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{totalCost | currency:'€'}}</b></td>
-        <td></td>
+        <td colspan="3"></td>
+        <td colspan="2"><span translate="TRAVEL_EXPENSE_REPORT.TOTAL"></span>: <b>{{report.expenses.totalCost() | currency:'€'}}</b></td>
+        <td colspan="3"><span translate="PAGES.EMPLOYEE.EXPENSES.REIMBURSEMENT"></span>: <b>{{report.expenses.totalReimbursement() | currency:'€'}}</b></td>
     </tr>
 </table>
 <div ng-show="report.status === 'SUBMITTED' && report.employee.id !== principal.id ">

--- a/src/modules/trackr/supervisor/expenses/editController.js
+++ b/src/modules/trackr/supervisor/expenses/editController.js
@@ -1,4 +1,4 @@
-define([], function() {
+define(['modules/trackr/employee/expenses/expensesDecorator'], function(expensesDecorator) {
         'use strict';
         return ['$scope', 'Restangular', 'trackr.services.travelExpenseReport', '$state', 'base.services.user', '$stateParams', 'base.services.notification',
             function($scope, Restangular, TravelExpenseReportService, $state, UserService, $stateParams, NotificationService) {
@@ -23,7 +23,7 @@ define([], function() {
                     .then(function(report) {
                         $scope.report = report;
                         $scope.report.statusTranslateCode = 'TRAVEL_EXPENSE_REPORT.' + report.status;
-                        $scope.totalCost = recalculateTotal(report.expenses);
+                        expensesDecorator($scope.report.expenses);
                     })
                     .catch(function(response) {
                         if(response && response.status === 404) {
@@ -31,17 +31,6 @@ define([], function() {
                             $scope.report = undefined;
                         }
                     });
-
-                /**
-                 * Recalculate the sum of the cost of the expenses
-                 * @param  expenses An array of expenses, each must have the property "cost".
-                 * @return The sum of all costs.
-                 */
-                function recalculateTotal(expenses) {
-                    return expenses.reduce(function(prev, expense) {
-                        return prev + parseFloat(expense.cost);
-                    }, 0);
-                }
 
                 $scope.report = {};
                 $scope.principal = UserService.getUser();

--- a/src/modules/trackr/supervisor/expenses/list.tpl.html
+++ b/src/modules/trackr/supervisor/expenses/list.tpl.html
@@ -27,7 +27,7 @@
             </tr>
             </thead>
             <tbody>
-            <tr ng-repeat="report in reports[state]">
+            <tr ng-repeat="report in reports[state] track by report.id">
                 <td><a ui-sref="app.trackr.supervisor.expenses.edit({id: report.id})">#{{report.id}}</a></td>
                 <td>{{ report.employee.firstName + ' ' + report.employee.lastName }}</td>
                 <td>{{ report.total | currency:'€' }}</td>

--- a/src/modules/trackr/supervisor/expenses/supervisorExpensesModule.js
+++ b/src/modules/trackr/supervisor/expenses/supervisorExpensesModule.js
@@ -1,0 +1,32 @@
+define(['angular', './editController', './listController'], function(angular, EditController, ListController) {
+    'use strict';
+    function config($stateProvider) {
+        $stateProvider
+            .state('app.trackr.supervisor.expenses', {
+                url: '/expenses',
+                breadcrumbTranslateCode: 'PAGES.SUPERVISOR.TRAVEL_EXPENSE_REPORTS.TITLE',
+                views: {
+                    'center@app': {
+                        templateUrl: 'src/modules/trackr/supervisor/expenses/list.tpl.html',
+                        controller: 'trackr.supervisor.expenses.ListController'
+                    }
+                }
+            })
+            .state('app.trackr.supervisor.expenses.edit', {
+                url: '/{id:\\d+}',
+                breadcrumbTranslateCode: 'ACTIONS.EDIT',
+                views: {
+                    'center@app': {
+                        templateUrl: 'src/modules/trackr/supervisor/expenses/edit.tpl.html',
+                        controller: 'trackr.supervisor.expenses.EditController'
+                    }
+                }
+            });
+    }
+
+    config.$inject = ['$stateProvider'];
+    var module = angular.module('trackr.supervisor.expenses', [], config);
+    module.controller('trackr.supervisor.expenses.ListController', ListController);
+    module.controller('trackr.supervisor.expenses.EditController', EditController);
+    return module;
+});

--- a/src/modules/trackr/supervisor/supervisorModule.js
+++ b/src/modules/trackr/supervisor/supervisorModule.js
@@ -1,6 +1,6 @@
-define(['angular', 'modules/trackr/supervisor/controllers'], function(angular, controllers) {
+define(['angular', './controllers', './expenses/supervisorExpensesModule'], function(angular, controllers) {
     'use strict';
-    var supervisor = angular.module('trackr.supervisor', []);
+    var supervisor = angular.module('trackr.supervisor', ['trackr.supervisor.expenses']);
 
     supervisor.config(['$stateProvider', function($stateProvider) {
         $stateProvider
@@ -40,26 +40,6 @@ define(['angular', 'modules/trackr/supervisor/controllers'], function(angular, c
                     'center@app': {
                         templateUrl: 'src/modules/trackr/supervisor/vacation/vacation.tpl.html',
                         controller: 'trackr.supervisor.controllers.vacation'
-                    }
-                }
-            })
-            .state('app.trackr.supervisor.expenses', {
-                url: '/expenses',
-                breadcrumbTranslateCode: 'PAGES.SUPERVISOR.TRAVEL_EXPENSE_REPORTS.TITLE',
-                views: {
-                    'center@app': {
-                        templateUrl: 'src/modules/trackr/supervisor/expenses/list.tpl.html',
-                        controller: 'trackr.supervisor.controllers.expenseReport-list'
-                    }
-                }
-            })
-            .state('app.trackr.supervisor.expenses.edit', {
-                url: '/{id:\\d+}',
-                breadcrumbTranslateCode: 'ACTIONS.EDIT',
-                views: {
-                    'center@app': {
-                        templateUrl: 'src/modules/trackr/supervisor/expenses/edit.tpl.html',
-                        controller: 'trackr.supervisor.controllers.expenseReport-edit'
                     }
                 }
             });

--- a/test/modules/trackr/employee/expenses/editControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/editControllerSpec.js
@@ -1,25 +1,20 @@
-define(['baseTestSetup', 'fixtures', 'confirmationServiceMock'], function(baseTestSetup, fixtures, ConfirmationServiceMock) {
+define(['baseTestSetup', 'fixtures'], function(baseTestSetup, fixtures) {
     'use strict';
-    describe('trackr.employee.controllers.expenseReport-edit', function() {
+    describe('trackr.employee.expenses.expenseReportEditController', function() {
         var EditController, scope;
         baseTestSetup();
         beforeEach(inject(function($rootScope, $controller) {
             scope = $rootScope.$new();
-            EditController = $controller('trackr.employee.controllers.expenseReport-edit', {
+            EditController = $controller('trackr.employee.expenses.expenseReportEditController', {
                 $scope: scope,
                 expenseTypes: fixtures['api/travelExpenses/types'],
-                $stateParams: { id: 0 },
-                'base.services.confirmation-dialog': ConfirmationServiceMock
+                $stateParams: { id: 0 }
             });
         }));
 
         beforeEach(inject(function($httpBackend) {
             $httpBackend.flush();
         }));
-
-        it('must calculate the total cost of the report on load', function() {
-            expect(scope.totalCost).toBeDefined();
-        });
 
         it('editable must return true if status is PENDING', function() {
             expect(scope.editable({status: 'PENDING'})).toBe(true);
@@ -36,16 +31,6 @@ define(['baseTestSetup', 'fixtures', 'confirmationServiceMock'], function(baseTe
         it('editable must return false if status is SUBMITTED', function() {
             expect(scope.editable({status: 'SUBMITTED'})).toBe(false);
         });
-
-        it('must call a DELETE when an expense is removed and update the expenses and totalCost', inject(function($httpBackend) {
-            var expensesBefore = scope.report.expenses.length;
-            var totalCostBefore = scope.totalCost;
-            scope.removeExpense(scope.report.expenses[0]);
-            $httpBackend.expectDELETE('api/travelExpenses/' + scope.report.expenses[0].id);
-            $httpBackend.flush();
-            expect(scope.report.expenses.length).toBe(expensesBefore - 1);
-            expect(scope.totalCost).toBeLessThan(totalCostBefore);
-        }));
 
         it('must call submit on the server when submitting', inject(function($httpBackend) {
             scope.submitReport(scope.report);

--- a/test/modules/trackr/employee/expenses/editControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/editControllerSpec.js
@@ -16,6 +16,11 @@ define(['baseTestSetup', 'fixtures'], function(baseTestSetup, fixtures) {
             $httpBackend.flush();
         }));
 
+        it('must decorate the expenses array', function() {
+            expect(scope.report.expenses.totalCost).toBeDefined();
+            expect(scope.report.expenses.totalReimbursement).toBeDefined();
+        });
+
         it('editable must return true if status is PENDING', function() {
             expect(scope.editable({status: 'PENDING'})).toBe(true);
         });

--- a/test/modules/trackr/employee/expenses/editControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/editControllerSpec.js
@@ -47,19 +47,6 @@ define(['baseTestSetup', 'fixtures', 'confirmationServiceMock'], function(baseTe
             expect(scope.totalCost).toBeLessThan(totalCostBefore);
         }));
 
-        it('must POST a new expense to the server on addNewExpense, set the report and submissionDate property on it', inject(function($httpBackend) {
-            var expense = {cost: 1};
-            var countExpenses = scope.report.expenses.length;
-            var oldTotalCost = scope.totalCost;
-            scope.addNewExpense(expense, scope.report);
-            $httpBackend.expectPOST('api/travelExpenses');
-            $httpBackend.flush();
-            expect(expense.report).toBeDefined();
-            expect(expense.submissionDate).toBeDefined();
-            expect(scope.report.expenses.length).toBe(countExpenses + 1);
-            expect(scope.totalCost).toBeGreaterThan(oldTotalCost);
-        }));
-
         it('must call submit on the server when submitting', inject(function($httpBackend) {
             scope.submitReport(scope.report);
             $httpBackend.expectPUT('api/travelExpenseReports/' + scope.report.id + '/submit');

--- a/test/modules/trackr/employee/expenses/editControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/editControllerSpec.js
@@ -32,10 +32,28 @@ define(['baseTestSetup', 'fixtures'], function(baseTestSetup, fixtures) {
             expect(scope.editable({status: 'SUBMITTED'})).toBe(false);
         });
 
+        it('deletable must return true if the status is PENDING', function() {
+            expect(scope.deletable({status: 'PENDING'})).toBe(true);
+        });
+
+        it('deletable must return true if the status is REJECTED', function() {
+            expect(scope.deletable({status: 'REJECTED'})).toBe(true);
+        });
+
+        it('deletable must return false if the status is SUBMITTED', function() {
+            expect(scope.deletable({status: 'SUBMITTED'})).toBe(false);
+        });
+
         it('must call submit on the server when submitting', inject(function($httpBackend) {
             scope.submitReport(scope.report);
             $httpBackend.expectPUT('api/travelExpenseReports/' + scope.report.id + '/submit');
             $httpBackend.flush();
         }));
+
+        it('must push an expense signalled with an event into the reports expense array', function() {
+            var numberOfExpensesBefore = scope.report.expenses.length;
+            scope.$emit('newExpense', {});
+            expect(scope.report.expenses.length).toBe(numberOfExpensesBefore + 1);
+        });
     });
 });

--- a/test/modules/trackr/employee/expenses/expenseEditControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/expenseEditControllerSpec.js
@@ -8,8 +8,10 @@ define(['baseTestSetup', 'angular'], function(baseTestSetup, angular) {
             EditController = $controller('trackr.employee.expenses.expenseEditController', {
                 $scope: scope,
                 'createOrUpdateModal.userdata': {
-                    expense: {},
-                    expenseTypes: []
+                    expense: {}
+                },
+                'trackr.services.travelExpense': {
+                    getTypes: function() { return ['TAXI']; }
                 }
             });
         }));

--- a/test/modules/trackr/employee/expenses/expenseEditControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/expenseEditControllerSpec.js
@@ -1,11 +1,11 @@
 define(['baseTestSetup'], function(baseTestSetup) {
     'use strict';
-    describe('trackr.employee.controllers.expense-edit', function() {
+    describe('trackr.employee.expenses.expenseEditController', function() {
         var EditController, scope;
         baseTestSetup();
         beforeEach(inject(function($rootScope, $controller) {
             scope = $rootScope.$new();
-            EditController = $controller('trackr.employee.controllers.expense-edit', {
+            EditController = $controller('trackr.employee.expenses.expenseEditController', {
                 $scope: scope,
                 'createOrUpdateModal.userdata': {
                     expense: {},

--- a/test/modules/trackr/employee/expenses/expenseEditControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/expenseEditControllerSpec.js
@@ -1,4 +1,4 @@
-define(['baseTestSetup'], function(baseTestSetup) {
+define(['baseTestSetup', 'angular'], function(baseTestSetup, angular) {
     'use strict';
     describe('trackr.employee.expenses.expenseEditController', function() {
         var EditController, scope;
@@ -20,6 +20,21 @@ define(['baseTestSetup'], function(baseTestSetup) {
 
         it('Must put the expense types in the scope', function() {
             expect(scope.expenseTypes).toBeDefined();
+        });
+
+        it('Must patch the expense when updating', inject(function($httpBackend) {
+            scope.closeModal = angular.noop;
+            scope.expense = {id: 0, type: 'TAXI'};
+            scope.saveEntity();
+            $httpBackend.expectPATCH('api/travelExpenses/0');
+            $httpBackend.flush();
+        }));
+
+        it('puts the errors in the scope when the response with the failure method', function() {
+            var response = {data: {errors: []}};
+            EditController.onFail(response);
+            expect(scope.errors).toBeDefined();
+            expect(scope.errors.length).toBe(0);
         });
     });
 });

--- a/test/modules/trackr/employee/expenses/expenseNewControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/expenseNewControllerSpec.js
@@ -1,11 +1,11 @@
 define(['baseTestSetup'], function(baseTestSetup) {
     'use strict';
-    describe('trackr.employee.controllers.expense-new', function() {
+    describe('trackr.employee.expenses.expenseNewController', function() {
         var NewController, scope;
         baseTestSetup();
         beforeEach(inject(function($controller, $rootScope) {
             scope = $rootScope.$new();
-            NewController = $controller('trackr.employee.controllers.expense-new', {
+            NewController = $controller('trackr.employee.expenses.expenseNewController', {
                 $scope: scope
             });
         }));

--- a/test/modules/trackr/employee/expenses/expenseNewControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/expenseNewControllerSpec.js
@@ -1,0 +1,25 @@
+define(['baseTestSetup'], function(baseTestSetup) {
+    'use strict';
+    describe('trackr.employee.controllers.expense-new', function() {
+        var NewController, scope;
+        baseTestSetup();
+        beforeEach(inject(function($controller, $rootScope) {
+            scope = $rootScope.$new();
+            NewController = $controller('trackr.employee.controllers.expense-new', {
+                $scope: scope
+            });
+        }));
+
+        it('must POST a new expense to the server on addNewExpense, set the report and submissionDate property on it', inject(function($httpBackend) {
+            scope.expense = {cost: 1};
+            var report = {
+                _links: {self: {href: 'report/1'}}
+            };
+            scope.addNewExpense(report);
+            $httpBackend.expectPOST('api/travelExpenses');
+            expect(scope.expense.report).toBe('report/1');
+            expect(scope.expense.submissionDate).toBeDefined();
+            $httpBackend.flush();
+        }));
+    });
+});

--- a/test/modules/trackr/employee/expenses/expensesDecoratorSpec.js
+++ b/test/modules/trackr/employee/expenses/expensesDecoratorSpec.js
@@ -1,0 +1,19 @@
+define(['modules/trackr/employee/expenses/expensesDecorator'], function(expensesDecorator) {
+    'use strict';
+    describe('The expenses decorator', function() {
+
+        it('must add a totalCost function to the array that calculates the sum of costs', function() {
+            var expenses = [{cost: 10}, {cost: 13}];
+            expensesDecorator(expenses);
+            expect(expenses.totalCost).toBeDefined();
+            expect(expenses.totalCost()).toBe(23);
+        });
+
+        it('must add a totalReimbursement function to the array that calculates the sum of non-paid costs', function() {
+            var expenses = [{cost: 10, paid: false}, {cost: 13, paid: true}];
+            expensesDecorator(expenses);
+            expect(expenses.totalReimbursement).toBeDefined();
+            expect(expenses.totalReimbursement()).toBe(10);
+        });
+    });
+});

--- a/test/modules/trackr/employee/expenses/expensesTableControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/expensesTableControllerSpec.js
@@ -11,18 +11,6 @@ define(['baseTestSetup', 'confirmationServiceMock'], function(baseTestSetup, Con
             });
         }));
 
-        it('must calculate the total cost of expenses', function() {
-            scope.expenses = [{cost: 10}, {cost: 13}];
-            var totalCost = scope.totalCost();
-            expect(totalCost).toBe(23);
-        });
-
-        it('must calculate the total reimbursement of expenses', function() {
-            scope.expenses = [{cost: 10, paid: true}, {cost: 13, paid: false}];
-            var totalReimbursement = scope.totalReimbursement();
-            expect(totalReimbursement).toBe(13);
-        });
-
         it('must call DELETE when removing an expense', inject(function($httpBackend) {
             scope.expenses = [{id: 0}, {id: 1}];
             scope.removeExpense(scope.expenses[1]);

--- a/test/modules/trackr/employee/expenses/expensesTableControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/expensesTableControllerSpec.js
@@ -1,0 +1,34 @@
+define(['baseTestSetup', 'confirmationServiceMock'], function(baseTestSetup, ConfirmationServiceMock) {
+    'use strict';
+    describe('trackr.employee.expenses.expenseTableController', function() {
+        var expenseTableController, scope;
+        baseTestSetup();
+        beforeEach(inject(function($rootScope, $controller) {
+            scope = $rootScope.$new();
+            expenseTableController = $controller('trackr.employee.expenses.expenseTableController', {
+                $scope: scope,
+                'base.services.confirmation-dialog': ConfirmationServiceMock
+            });
+        }));
+
+        it('must calculate the total cost of expenses', function() {
+            scope.expenses = [{cost: 10}, {cost: 13}];
+            var totalCost = scope.totalCost();
+            expect(totalCost).toBe(23);
+        });
+
+        it('must calculate the total reimbursement of expenses', function() {
+            scope.expenses = [{cost: 10, paid: true}, {cost: 13, paid: false}];
+            var totalReimbursement = scope.totalReimbursement();
+            expect(totalReimbursement).toBe(13);
+        });
+
+        it('must call DELETE when removing an expense', inject(function($httpBackend) {
+            scope.expenses = [{id: 0}, {id: 1}];
+            scope.removeExpense(scope.expenses[1]);
+            $httpBackend.expectDELETE('api/travelExpenses/' + scope.expenses[1].id);
+            $httpBackend.flush();
+            expect(scope.expenses.length).toBe(1);
+        }));
+    });
+});

--- a/test/modules/trackr/employee/expenses/listControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/listControllerSpec.js
@@ -1,6 +1,6 @@
 define(['baseTestSetup', 'fixtures', 'angular'], function(baseTestSetup, fixtures, angular) {
     'use strict';
-    describe('trackr.employee.controllers.expenseReport-list', function() {
+    describe('trackr.employee.expenses.expenseReportListController', function() {
         var ListController, scope, state;
         baseTestSetup();
         beforeEach(inject(function($rootScope, $controller) {
@@ -12,12 +12,22 @@ define(['baseTestSetup', 'fixtures', 'angular'], function(baseTestSetup, fixture
                 go: angular.noop
             };
             var reports = fixtures['api/travelExpenseReports']._embedded.travelExpenseReports;
-            ListController = $controller('trackr.employee.controllers.expenseReport-list', {
+            ListController = $controller('trackr.employee.expenses.expenseReportListController', {
                 $scope: scope,
                 reports: reports,
                 $state: state,
                 employee: employee
             });
         }));
+
+        beforeEach(inject(function($httpBackend) {
+            $httpBackend.flush();
+        }));
+
+        it('calculateReportTotal must sum up all costs.', function() {
+            var report = {expenses: [{cost: 10}, {cost: 13}]};
+            var totalCost = ListController.calculateReportTotal(report);
+            expect(totalCost).toBe(23);
+        });
     });
 });

--- a/test/modules/trackr/employee/expenses/reportNewControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/reportNewControllerSpec.js
@@ -1,0 +1,57 @@
+define(['baseTestSetup', 'angular'], function(baseTestSetup, angular) {
+    'use strict';
+    describe('trackr.employee.expenses.expenseReportNewController', function() {
+        var NewController, scope;
+        baseTestSetup();
+        beforeEach(inject(function($rootScope, $controller) {
+            scope = $rootScope.$new();
+            scope.closeModal = angular.noop;
+            NewController = $controller('trackr.employee.expenses.expenseReportNewController', {
+                $scope: scope,
+                'trackr.services.employee': {
+                    getEmployeeHref: function() {
+                        return {
+                            _links: {self: {href:'employee/1'}}
+                        };
+                    }
+                }
+            });
+        }));
+
+        it('must load all projects for the company', inject(function($httpBackend, $q) {
+            var company = {
+                all: function() {
+                    return {
+                        getList: function() {
+                            return $q.when([{id: 0}]);
+                        }
+                    };
+                }
+            };
+            scope.loadProjects(company);
+            scope.$digest();
+            expect(scope.projects).toBeDefined();
+            expect(scope.projects.length).toBe(1);
+        }));
+
+        it('POSTs a new report when saving', inject(function($httpBackend) {
+            scope.saveEntity();
+            $httpBackend.expectPOST('api/travelExpenseReports');
+            $httpBackend.flush();
+        }));
+
+        it('adds the company to the report if it is set', inject(function($httpBackend) {
+            NewController.company = {_links: {self: {href: 'companies/1'}}};
+            scope.saveEntity();
+            expect(scope.report.debitor).toBe('companies/1');
+            $httpBackend.flush();
+        }));
+
+        it('adds the project to the report if it is set', inject(function($httpBackend) {
+            NewController.project = {_links: {self: {href: 'projects/1'}}};
+            scope.saveEntity();
+            expect(scope.report.project).toBe('projects/1');
+            $httpBackend.flush();
+        }));
+    });
+});

--- a/test/modules/trackr/supervisor/expenses/editControllerSpec.js
+++ b/test/modules/trackr/supervisor/expenses/editControllerSpec.js
@@ -1,6 +1,6 @@
 define(['baseTestSetup', 'fixtures', 'angular'], function(baseTestSetup, fixtures, angular) {
     'use strict';
-    describe('trackr.supervisor.controllers.expenseReport-edit', function() {
+    describe('trackr.supervisor.expenses.EditController', function() {
         var EditController, scope, state;
         baseTestSetup();
         beforeEach(inject(function($rootScope, $controller) {
@@ -10,7 +10,7 @@ define(['baseTestSetup', 'fixtures', 'angular'], function(baseTestSetup, fixture
             state = {
                 go: angular.noop
             };
-            EditController = $controller('trackr.supervisor.controllers.expenseReport-edit', {
+            EditController = $controller('trackr.supervisor.expenses.EditController', {
                 $scope: scope,
                 expenses: report.expenses,
                 report: report,
@@ -25,8 +25,9 @@ define(['baseTestSetup', 'fixtures', 'angular'], function(baseTestSetup, fixture
             $httpBackend.flush();
         }));
 
-        it('must calculate the total cost of the report on load', function() {
-            expect(scope.totalCost).toBeDefined();
+        it('must decorate the expenses array', function() {
+            expect(scope.report.expenses.totalCost).toBeDefined();
+            expect(scope.report.expenses.totalReimbursement).toBeDefined();
         });
 
         it('must call approve on the server when approving', inject(function($httpBackend) {

--- a/test/modules/trackr/supervisor/expenses/listControllerSpec.js
+++ b/test/modules/trackr/supervisor/expenses/listControllerSpec.js
@@ -1,11 +1,11 @@
 define(['baseTestSetup'], function(baseTestSetup) {
     'use strict';
-    describe('trackr.supervisor.controllers.expenseReport-list', function() {
+    describe('trackr.supervisor.expenses.ListController', function() {
         var ListController, scope;
         baseTestSetup();
         beforeEach(inject(function($rootScope, $controller) {
             scope = $rootScope.$new();
-            ListController = $controller('trackr.supervisor.controllers.expenseReport-list', {
+            ListController = $controller('trackr.supervisor.expenses.ListController', {
                 $scope: scope
             });
         }));


### PR DESCRIPTION
This is the frontend part to mark expenses as paid. It adds the following:
* Employees can mark expenses as paid on creation or updating
* The expense report page also shows the reimbursement (not containing the paid expenses), both for supervisors and employees

Apart from that the employee and supervisor module were refactored:
* For both the expense part is a submodule now
* The employee page was slightly redesigned, the new expense form is now on the right
* Large controllers were broken into smaller components
* Common functionality was encapsulated