### PR TITLE
TRACKR-227 - Show approver for travel expense report in detail view

### DIFF
--- a/src/modules/trackr/employee/expenses/edit.tpl.html
+++ b/src/modules/trackr/employee/expenses/edit.tpl.html
@@ -2,7 +2,9 @@
     <pdf-download url="api/travelExpenseReports/{{report.id}}/pdf" filename="report-{{report.id}}.pdf"></pdf-download>
 </h2>
 <span class="pull-right"><a href ui-sref="app.trackr.employee.expenses" translate="ACTIONS.BACK"></a></span>
-<h4>{{ 'TRAVEL_EXPENSE_REPORT.' + report.status | translate }}</h4>
+<h4>{{ 'TRAVEL_EXPENSE_REPORT.' + report.status | translate }}
+    <span ng-show="report.status === 'APPROVED'">({{report.approver.firstName + ' ' + report.approver.lastName}})</span>
+</h4>
 <h5>{{ report.debitor.name }} <span ng-show="report.project"> - {{report.project.name}}</span></h5>
 <table class="table table-striped">
     <tr>

--- a/src/modules/trackr/employee/expenses/editController.js
+++ b/src/modules/trackr/employee/expenses/editController.js
@@ -18,7 +18,7 @@ define(['lodash'], function(_) {
             };
 
             Restangular.one('travelExpenseReports', $stateParams.id).get({
-                projection: 'withExpensesAndDebitorAndProject'
+                projection: 'overview'
             })
                 .then(function(report) {
                     return report.all('comments').getList({

--- a/src/modules/trackr/employee/expenses/listController.js
+++ b/src/modules/trackr/employee/expenses/listController.js
@@ -27,7 +27,7 @@ define(['modules/shared/PaginationLoader', 'lodash'], function(PaginationLoader,
 
         controller.loadPage = function(page, state) {
             var params = {
-                projection: 'withExpensesAndDebitorAndProject',
+                projection: 'overview',
                 employee: employee.id
             };
             if (state) {

--- a/src/modules/trackr/supervisor/expenses/edit.tpl.html
+++ b/src/modules/trackr/supervisor/expenses/edit.tpl.html
@@ -6,6 +6,9 @@
 <div ng-if="report">
 <h2><span translate="TRAVEL_EXPENSE_REPORT.TRAVEL_EXPENSE_REPORT"></span> #{{report.id}}</h2>
 <h3>{{report.employee.firstName}} {{report.employee.lastName}}</h3>
+<h4 ng-show="report.status === 'APPROVED'">
+    <span translate="PAGES.SUPERVISOR.TRAVEL_EXPENSE_REPORTS.APPROVED_BY"></span> {{report.approver.firstName + ' ' + report.approver.lastName}}
+</h4>
 <span class="pull-right"><a href ui-sref="app.trackr.supervisor.expenses" translate="ACTIONS.BACK"></a></span>
 <div class="row">
     <div class="col-md-3 form-group">


### PR DESCRIPTION
Added the approver to the edit page of a travel expense report for both supervisor and employee.

Also fixed a bug where the approver was not displayed for employees in the list.