### PR TITLE
TRACKR-234 - Track employee contact address

### DIFF
--- a/src/modules/trackr/administration/administrationModule.js
+++ b/src/modules/trackr/administration/administrationModule.js
@@ -1,6 +1,6 @@
-define(['angular', 'modules/trackr/administration/controllers'], function(angular, controllers) {
+define(['angular', 'modules/trackr/administration/controllers', './employees/adminEmployeeModule'], function(angular, controllers) {
     'use strict';
-    var administration = angular.module('trackr.administration', []);
+    var administration = angular.module('trackr.administration', ['trackr.administration.employees']);
 
     administration.config(['$stateProvider', function($stateProvider) {
         $stateProvider
@@ -31,27 +31,6 @@ define(['angular', 'modules/trackr/administration/controllers'], function(angula
                 'company': {
                     templateUrl: 'src/modules/trackr/administration/companies/display.tpl.html',
                     controller: 'trackr.administration.controllers.companies.display'
-                }
-            },
-            needsAuthority: 'ROLE_SUPERVISOR'
-        })
-        .state('app.trackr.administration.employees', {
-            url: '/employees',
-            breadcrumbTranslateCode: 'EMPLOYEE.EMPLOYEES',
-            views: {
-                'center@app': {
-                    templateUrl: 'src/modules/trackr/administration/employees/list.tpl.html',
-                    controller: 'trackr.administration.controllers.employees.list'
-                }
-            },
-            needsAuthority: 'ROLE_SUPERVISOR'
-        })
-        .state('app.trackr.administration.employees.edit', {
-            url: '/{id:[\\d]+}',
-            views: {
-                'employee': {
-                    templateUrl: 'src/modules/trackr/administration/employees/display.tpl.html',
-                    controller: 'trackr.administration.controllers.employees.display'
                 }
             },
             needsAuthority: 'ROLE_SUPERVISOR'

--- a/src/modules/trackr/administration/controllers.js
+++ b/src/modules/trackr/administration/controllers.js
@@ -1,8 +1,4 @@
 define([
-    'modules/trackr/administration/employees/displayController',
-    'modules/trackr/administration/employees/editController',
-    'modules/trackr/administration/employees/newController',
-    'modules/trackr/administration/employees/listController',
     'modules/trackr/administration/companies/listController',
     'modules/trackr/administration/companies/displayController',
     'modules/trackr/administration/companies/editController',
@@ -12,17 +8,12 @@ define([
     'modules/trackr/administration/projects/editController',
     'modules/trackr/administration/projects/displayController',
     'modules/trackr/administration/projects/newController'
-], function(EmployeeDisplayController, EmployeeEditController, EmployeeNewController, EmployeeListController,
-            CompaniesListController, CompaniesDisplayController, CompaniesEditController, CompaniesNewController,
+], function(CompaniesListController, CompaniesDisplayController, CompaniesEditController, CompaniesNewController,
             ContactPersonsNewOrEditController,
             ProjectsListController, ProjectsEditController, ProjectsDisplayController, ProjectsNewController) {
     'use strict';
     return {
         init: function(module) {
-            module.controller('trackr.administration.controllers.employees.display', EmployeeDisplayController);
-            module.controller('trackr.administration.controllers.employees.edit', EmployeeEditController);
-            module.controller('trackr.administration.controllers.employees.new', EmployeeNewController);
-            module.controller('trackr.administration.controllers.employees.list', EmployeeListController);
             module.controller('trackr.administration.controllers.companies.list', CompaniesListController);
             module.controller('trackr.administration.controllers.companies.display', CompaniesDisplayController);
             module.controller('trackr.administration.controllers.companies.edit', CompaniesEditController);

--- a/src/modules/trackr/administration/employees/addressEdit.tpl.html
+++ b/src/modules/trackr/administration/employees/addressEdit.tpl.html
@@ -1,0 +1,7 @@
+<form class="form-horizontal">
+    <bs-text property-name="street" translate-code="ADDRESS.STREET" path="ctrl.address.street"></bs-text>
+    <bs-text property-name="houseNumber" translate-code="ADDRESS.HOUSE_NUMBER" path="ctrl.address.houseNumber"></bs-text>
+    <bs-text property-name="zipCode" translate-code="ADDRESS.ZIPCODE" path="ctrl.address.zipCode"></bs-text>
+    <bs-text property-name="city" translate-code="ADDRESS.CITY" path="ctrl.address.city"></bs-text>
+    <bs-text property-name="country" translate-code="ADDRESS.COUNTRY" path="ctrl.address.country"></bs-text>
+</form>

--- a/src/modules/trackr/administration/employees/addressEditController.js
+++ b/src/modules/trackr/administration/employees/addressEditController.js
@@ -1,0 +1,47 @@
+define(['lodash'], function(_) {
+    'use strict';
+    function addressEditController(employee, $scope, Restangular) {
+        /*jshint validthis:true */
+        var controller = this;
+        controller.address = _.clone(employee.address);
+
+        $scope.saveEntity = function() {
+            var address = _.pick(controller.address, ['id', 'version', 'street', 'houseNumber', 'zipCode', 'city', 'country']);
+            if(address.id === undefined) {
+                createNewAddress(address);
+            } else {
+                updateAddress(address);
+            }
+        };
+
+        function createNewAddress(address) {
+            Restangular.all('addresses').post(address)
+                .then(function(savedAddress) {
+                    setAddressOnEmployee(savedAddress)
+                        .then(function() {
+                            $scope.closeModal(savedAddress);
+                        });
+                }, onFailedRequest);
+        }
+
+        function setAddressOnEmployee(address) {
+            return Restangular.one('employees', employee.id)
+                .customOperation('put', 'address', {}, {'Content-Type': 'text/uri-list'}, address._links.self.href);
+        }
+
+        function updateAddress(address) {
+            var request = Restangular.one('addresses', address.id);
+            _.assign(request, address);
+            request.put().then(function(updatedAddress) {
+                $scope.closeModal(updatedAddress);
+            }, onFailedRequest);
+        }
+
+         function onFailedRequest(response) {
+            $scope.errors = response.data.errors;
+        }
+    }
+
+    addressEditController.$inject = ['createOrUpdateModal.userdata', '$scope', 'Restangular'];
+    return addressEditController;
+});

--- a/src/modules/trackr/administration/employees/addressEditController.js
+++ b/src/modules/trackr/administration/employees/addressEditController.js
@@ -37,7 +37,7 @@ define(['lodash'], function(_) {
             }, onFailedRequest);
         }
 
-         function onFailedRequest(response) {
+        function onFailedRequest(response) {
             $scope.errors = response.data.errors;
         }
     }

--- a/src/modules/trackr/administration/employees/adminEmployeeModule.js
+++ b/src/modules/trackr/administration/employees/adminEmployeeModule.js
@@ -1,5 +1,5 @@
-define(['angular', './editController', './listController', './newController', './displayController'],
-    function(angular, EditController, ListController, NewController, DisplayController) {
+define(['angular', './editController', './listController', './newController', './displayController', './addressEditController'],
+    function(angular, EditController, ListController, NewController, DisplayController, AddressEditController) {
         'use strict';
         function config($stateProvider) {
             $stateProvider
@@ -31,6 +31,7 @@ define(['angular', './editController', './listController', './newController', '.
 
         module.controller('trackr.administration.employees.displayController', DisplayController);
         module.controller('trackr.administration.employees.editController', EditController);
+        module.controller('trackr.administration.employees.addressEditController', AddressEditController);
         module.controller('trackr.administration.employees.newController', NewController);
         module.controller('trackr.administration.employees.listController', ListController);
         return module;

--- a/src/modules/trackr/administration/employees/adminEmployeeModule.js
+++ b/src/modules/trackr/administration/employees/adminEmployeeModule.js
@@ -1,0 +1,37 @@
+define(['angular', './editController', './listController', './newController', './displayController'],
+    function(angular, EditController, ListController, NewController, DisplayController) {
+        'use strict';
+        function config($stateProvider) {
+            $stateProvider
+                .state('app.trackr.administration.employees.edit', {
+                    url: '/{id:[\\d]+}',
+                    views: {
+                        'employee': {
+                            templateUrl: 'src/modules/trackr/administration/employees/display.tpl.html',
+                            controller: 'trackr.administration.employees.displayController'
+                        }
+                    },
+                    needsAuthority: 'ROLE_SUPERVISOR'
+                })
+                .state('app.trackr.administration.employees', {
+                    url: '/employees',
+                    breadcrumbTranslateCode: 'EMPLOYEE.EMPLOYEES',
+                    views: {
+                        'center@app': {
+                            templateUrl: 'src/modules/trackr/administration/employees/list.tpl.html',
+                            controller: 'trackr.administration.employees.listController'
+                        }
+                    },
+                    needsAuthority: 'ROLE_SUPERVISOR'
+                });
+        }
+
+        config.$inject = ['$stateProvider'];
+        var module = angular.module('trackr.administration.employees', [], config);
+
+        module.controller('trackr.administration.employees.displayController', DisplayController);
+        module.controller('trackr.administration.employees.editController', EditController);
+        module.controller('trackr.administration.employees.newController', NewController);
+        module.controller('trackr.administration.employees.listController', ListController);
+        return module;
+    });

--- a/src/modules/trackr/administration/employees/display.tpl.html
+++ b/src/modules/trackr/administration/employees/display.tpl.html
@@ -29,6 +29,20 @@
             <dd>{{ employee.leaveDate | date:'dd.MM.yyyy' }}</dd>
         </dl>
 
+        <h1 class="page-header">
+            <translate translate="ADDRESS.ADDRESS"></translate>
+            <button has-authority="ROLE_ADMIN" type="button" class="pull-right btn btn-default btn-sm" ng-click="showAddressEditForm()">
+                <span class="glyphicon glyphicon-pencil"></span>
+            </button>
+        </h1>
+        <dl class="dl-horizontal">
+            <dt></dt>
+            <dd>
+                {{employee.address.street}} {{employee.address.houseNumber}}<br/>
+                {{employee.address.zipCode}} {{employee.address.city}}<br/>
+                {{employee.address.country}}
+            </dd>
+        </dl>
     </div>
 
 </section>

--- a/src/modules/trackr/administration/employees/displayController.js
+++ b/src/modules/trackr/administration/employees/displayController.js
@@ -17,10 +17,24 @@ define([], function() {
             });
         };
 
+        $scope.showAddressEditForm = function() {
+            var $modalInstance = createOrUpdateModalService
+                .showModal('trackr.administration.employees.addressEditController as ctrl',
+                'src/modules/trackr/administration/employees/addressEdit.tpl.html',
+                'ACTIONS.EDIT',
+                $scope.employee
+            );
+            $modalInstance.result.then(function(address) {
+                $scope.employee.address = address;
+            });
+        };
+
         /*
          Initial load of employee and associated data.
          */
-        Restangular.one('employees', $stateParams.id).get()
+        Restangular.one('employees', $stateParams.id).get({
+                projection: 'withAddress'
+            })
             .then(function(employee) {
                 $scope.employee = employee;
             });

--- a/src/modules/trackr/administration/employees/displayController.js
+++ b/src/modules/trackr/administration/employees/displayController.js
@@ -4,7 +4,7 @@ define([], function() {
 
         $scope.showEditForm = function() {
             var $modalInstance= createOrUpdateModalService
-                .showModal('trackr.administration.controllers.employees.edit as ctrl',
+                .showModal('trackr.administration.employees.editController as ctrl',
                 'src/modules/trackr/administration/employees/newOrEdit.tpl.html',
                 'ACTIONS.EDIT',
                 {

--- a/src/modules/trackr/administration/employees/listController.js
+++ b/src/modules/trackr/administration/employees/listController.js
@@ -12,7 +12,7 @@ define(['modules/shared/PaginationLoader'], function (PaginationLoader) {
 
         $scope.addNew = function() {
             var $modalInstance = createOrUpdateModalService
-                .showModal('trackr.administration.controllers.employees.new as ctrl',
+                .showModal('trackr.administration.employees.newController as ctrl',
                 'src/modules/trackr/administration/employees/newOrEdit.tpl.html',
                 'EMPLOYEE.CREATE_NEW'
             );

--- a/src/modules/trackr/employee/address_book/addressBookController.js
+++ b/src/modules/trackr/employee/address_book/addressBookController.js
@@ -1,7 +1,7 @@
 define(['modules/shared/PaginationLoader'], function(PaginationLoader) {
     'use strict';
     return ['Restangular', '$scope', function(Restangular, $scope) {
-        var paginationLoader = new PaginationLoader(Restangular.all('address_book'), 'employees', 'lastName,asc', $scope, 20);
+        var paginationLoader = new PaginationLoader(Restangular.all('address_book'), 'employees', 'lastName,asc', $scope, 10);
 
         $scope.setPage = function() {
             paginationLoader.loadPage($scope.employees.page.number);

--- a/src/modules/trackr/employee/address_book/address_book.tpl.html
+++ b/src/modules/trackr/employee/address_book/address_book.tpl.html
@@ -16,9 +16,7 @@
         <th table-sort="email">
             <translate translate="CREDENTIAL.EMAIL"></translate>
         </th>
-        <th>
-            Address
-        </th>
+        <th translate="ADDRESS.ADDRESS"></th>
     </tr>
     <tr ng-repeat="employee in employees track by employee.id">
         <td>{{employee.firstName}}</td>

--- a/src/modules/trackr/employee/address_book/address_book.tpl.html
+++ b/src/modules/trackr/employee/address_book/address_book.tpl.html
@@ -13,16 +13,24 @@
         <th table-sort="phoneNumber">
             <translate translate="EMPLOYEE.PHONE_NUMBER"></translate>
         </th>
-        <th table-sort="credential.email">
+        <th table-sort="email">
             <translate translate="CREDENTIAL.EMAIL"></translate>
         </th>
+        <th>
+            Address
+        </th>
     </tr>
-    <tr ng-repeat="employee in employees">
+    <tr ng-repeat="employee in employees track by employee.id">
         <td>{{employee.firstName}}</td>
         <td>{{employee.lastName}}</td>
         <td>{{employee.title}}</td>
         <td>{{employee.phoneNumber}}</td>
         <td><a href="mailto:{{employee.email}}">{{employee.email}}</a></td>
+        <td>
+            {{employee.address.street}} {{employee.address.houseNumber}}<br/>
+            {{employee.address.zipCode}} {{employee.address.city}}<br/>
+            {{employee.address.country}}
+        </td>
     </tr>
 </table>
 

--- a/src/modules/trackr/employee/self-edit.tpl.html
+++ b/src/modules/trackr/employee/self-edit.tpl.html
@@ -2,4 +2,9 @@
     <bs-text property-name="firstName" translate-code="EMPLOYEE.FIRST_NAME" path="employee.firstName"></bs-text>
     <bs-text property-name="lastName" translate-code="EMPLOYEE.LAST_NAME" path="employee.lastName"></bs-text>
     <bs-text property-name="phoneNumber" translate-code="EMPLOYEE.PHONE_NUMBER" path="employee.phoneNumber"></bs-text>
+    <bs-text property-name="address.street" translate-code="ADDRESS.STREET" path="employee.address.street"></bs-text>
+    <bs-text property-name="address.houseNumber" translate-code="ADDRESS.HOUSE_NUMBER" path="employee.address.houseNumber"></bs-text>
+    <bs-text property-name="address.zipCode" translate-code="ADDRESS.ZIPCODE" path="employee.address.zipCode"></bs-text>
+    <bs-text property-name="address.city" translate-code="ADDRESS.CITY" path="employee.address.city"></bs-text>
+    <bs-text property-name="address.country" translate-code="ADDRESS.COUNTRY" path="employee.address.country"></bs-text>
 </form>

--- a/src/modules/trackr/employee/self.tpl.html
+++ b/src/modules/trackr/employee/self.tpl.html
@@ -11,4 +11,10 @@
     <dd>{{ employee.salary | currency:'€' }}</dd>
     <dt translate="EMPLOYEE.PHONE_NUMBER"></dt>
     <dd>{{employee.phoneNumber}}</dd>
+    <dt translate="ADDRESS.STREET"></dt>
+    <dd>{{employee.address.street}} {{employee.address.houseNumber}}</dd>
+    <dt translate="ADDRESS.CITY"></dt>
+    <dd>{{employee.address.zipCode}} {{employee.address.city}}</dd>
+    <dt translate="ADDRESS.COUNTRY"></dt>
+    <dd>{{employee.address.country}}</dd>
 </dl>

--- a/src/modules/trackr/employee/selfController.js
+++ b/src/modules/trackr/employee/selfController.js
@@ -1,10 +1,11 @@
 define([], function() {
     'use strict';
-    return ['$scope', 'base.services.user', 'Restangular', 'shared.services.create-or-update-modal', function($scope, UserService, Restangular, createOrUpdateModalService) {
+    function selfController($scope, UserService, Restangular, createOrUpdateModalService) {
         var user = UserService.getUser();
-        Restangular.one('employees', user.id).get().then(function(employee) {
-            $scope.employee = employee;
-        });
+        Restangular.oneUrl('employees', 'api/employees/' + user.id + '/self').get()
+            .then(function(employee) {
+                $scope.employee = employee;
+            });
 
         $scope.showEditForm = function() {
             var $modalInstance = createOrUpdateModalService
@@ -16,8 +17,7 @@ define([], function() {
             });
         };
 
-        $scope.updateEmployee = function(patch) {
-            return Restangular.oneUrl('employees', 'api/employees/' + user.id + '/self').patch(patch);
-        };
-    }];
+    }
+    selfController.$inject = ['$scope', 'base.services.user', 'Restangular', 'shared.services.create-or-update-modal'];
+    return selfController;
 });

--- a/src/modules/trackr/employee/selfController.js
+++ b/src/modules/trackr/employee/selfController.js
@@ -2,7 +2,7 @@ define([], function() {
     'use strict';
     function selfController($scope, UserService, Restangular, createOrUpdateModalService) {
         var user = UserService.getUser();
-        Restangular.oneUrl('employees', 'api/employees/' + user.id + '/self').get()
+        Restangular.one('employees', user.id).one('self').get()
             .then(function(employee) {
                 $scope.employee = employee;
             });

--- a/src/modules/trackr/employee/selfEditController.js
+++ b/src/modules/trackr/employee/selfEditController.js
@@ -5,10 +5,11 @@ define(['lodash'], function(_) {
         $scope.employee = _.clone(employee, false);
 
         controller.saveEntity = function(employee) {
-            var employeeEntity = _.pick(employee, ['phoneNumber', 'firstName', 'lastName']);
-            Restangular.oneUrl('employees', 'api/employees/' + employee.id + '/self').patch(employeeEntity)
-                .then(function() {
-                    $scope.closeModal(employee);
+            var request = Restangular.oneUrl('employees', 'api/employees/' + employee.id + '/self');
+            _.assign(request, _.pick(employee, ['version', 'phoneNumber', 'firstName', 'lastName', 'address']));
+            request.put()
+                .then(function(updatedEmployee) {
+                    $scope.closeModal(updatedEmployee);
                 }, function(response) {
                     $scope.errors = response.data.errors;
                 });

--- a/src/modules/trackr/employee/selfEditController.js
+++ b/src/modules/trackr/employee/selfEditController.js
@@ -5,7 +5,7 @@ define(['lodash'], function(_) {
         $scope.employee = _.clone(employee, true);
 
         controller.saveEntity = function(employee) {
-            var request = Restangular.oneUrl('employees', 'api/employees/' + employee.id + '/self');
+            var request = Restangular.one('employees', employee.id).one('self');
             _.assign(request, _.pick(employee, ['version', 'phoneNumber', 'firstName', 'lastName', 'address']));
             request.put()
                 .then(function(updatedEmployee) {

--- a/src/modules/trackr/employee/selfEditController.js
+++ b/src/modules/trackr/employee/selfEditController.js
@@ -2,7 +2,7 @@ define(['lodash'], function(_) {
     'use strict';
     return ['createOrUpdateModal.userdata', '$scope', 'Restangular', function(employee, $scope, Restangular) {
         var controller = this;
-        $scope.employee = _.clone(employee, false);
+        $scope.employee = _.clone(employee, true);
 
         controller.saveEntity = function(employee) {
             var request = Restangular.oneUrl('employees', 'api/employees/' + employee.id + '/self');

--- a/test/backendMock.js
+++ b/test/backendMock.js
@@ -97,7 +97,8 @@ define(['fixtures'], function(fixtures) {
         mockPatch('api/employees');
         mockPost('api/employees');
         $httpBackend.whenGET(/^api\/employees\/\d+$/).respond(fixtures['api/employees']._embedded.employees[0]);
-        $httpBackend.whenPATCH(/^api\/employees\/\d+\/self$/).respond(function(method, url, data) {
+        $httpBackend.whenGET(/^api\/employees\/\d+\/self$/).respond(fixtures['api/employees']._embedded.employees[0]);
+        $httpBackend.whenPUT(/^api\/employees\/\d+\/self$/).respond(function(method, url, data) {
             return [200, data];
         });
 

--- a/test/backendMock.js
+++ b/test/backendMock.js
@@ -52,6 +52,9 @@ define(['fixtures'], function(fixtures) {
                 var address = { _links: { self: { href: '' } } };
                 return [200, address];
             });
+        $httpBackend.whenPUT(/^api\/addresses\/\d+$/).respond(function(method, url, data) {
+            return [201, data];
+        });
 
         //#### -- BILLABLE TIMES
         mockPost('api/billableTimes');
@@ -97,10 +100,16 @@ define(['fixtures'], function(fixtures) {
         mockPatch('api/employees');
         mockPost('api/employees');
         $httpBackend.whenGET(/^api\/employees\/\d+$/).respond(fixtures['api/employees']._embedded.employees[0]);
+        $httpBackend.whenGET(/^api\/employees\/\d+\?projection=withAddress$/).respond(function() {
+            var employee = fixtures['api/employees']._embedded.employees[0];
+            employee.address = fixtures['api/addresses']._embedded.addresses[0];
+            return [200, employee];
+        });
         $httpBackend.whenGET(/^api\/employees\/\d+\/self$/).respond(fixtures['api/employees']._embedded.employees[0]);
         $httpBackend.whenPUT(/^api\/employees\/\d+\/self$/).respond(function(method, url, data) {
             return [200, data];
         });
+        $httpBackend.whenPUT(/^api\/employees\/\d+\/address$/).respond([204]);
 
         //#### -- FEDERAL STATES
         mockRoot('api/federalStates');

--- a/test/modules/trackr/administration/employees/addressEditControllerSpec.js
+++ b/test/modules/trackr/administration/employees/addressEditControllerSpec.js
@@ -1,0 +1,32 @@
+define(['baseTestSetup', 'angular'], function(baseTestSetup, angular) {
+    'use strict';
+    describe('trackr.administration.employees.addressEditController', function() {
+        var AddressEditController, scope;
+
+        baseTestSetup();
+
+        beforeEach(inject(function($rootScope, $controller) {
+            scope = $rootScope.$new();
+            scope.closeModal = angular.noop;
+            AddressEditController = $controller('trackr.administration.employees.addressEditController', {
+                'createOrUpdateModal.userdata': {id: 0},
+                '$scope': scope
+            });
+        }));
+
+        it('create a new address and updates the employee when the address is new.', inject(function($httpBackend) {
+            AddressEditController.address = {street: 'foo'};
+            scope.saveEntity();
+            $httpBackend.expectPOST('api/addresses');
+            $httpBackend.expectPUT('api/employees/0/address');
+            $httpBackend.flush();
+        }));
+
+        it('updates an existing address', inject(function($httpBackend) {
+            AddressEditController.address = {id: 0, street: 'foo'};
+            scope.saveEntity();
+            $httpBackend.expectPUT('api/addresses/0');
+            $httpBackend.flush();
+        }));
+    });
+});

--- a/test/modules/trackr/administration/employees/displayControllerSpec.js
+++ b/test/modules/trackr/administration/employees/displayControllerSpec.js
@@ -1,11 +1,11 @@
 define(['baseTestSetup'], function(baseTestSetup) {
     'use strict';
-    describe('trackr.administration.controllers.employees.display', function () {
+    describe('trackr.administration.employees.displayController', function () {
         var EditController, scope;
         baseTestSetup();
         beforeEach(inject(function($rootScope, $controller) {
             scope = $rootScope.$new();
-            EditController = $controller('trackr.administration.controllers.employees.display', {
+            EditController = $controller('trackr.administration.employees.displayController', {
                 $scope: scope,
                 $stateParams: {
                     id: 0

--- a/test/modules/trackr/administration/employees/editControllerSpec.js
+++ b/test/modules/trackr/administration/employees/editControllerSpec.js
@@ -1,14 +1,17 @@
-define(['baseTestSetup'], function(baseTestSetup) {
+define(['baseTestSetup', 'angular'], function(baseTestSetup, angular) {
     'use strict';
     describe('trackr.administration.employees.editController', function () {
         var EditController, scope;
         baseTestSetup();
         beforeEach(inject(function($rootScope, $controller) {
             scope = $rootScope.$new();
+            scope.closeModal = angular.noop;
             EditController = $controller('trackr.administration.employees.editController', {
                 $scope: scope,
                 'createOrUpdateModal.userdata': {
                     employee: {
+                        id: 0,
+                        federalState: {name: 'BERLIN'}
                     },
                     states: []
                 }
@@ -22,5 +25,11 @@ define(['baseTestSetup'], function(baseTestSetup) {
         it('must have the federal states in scope', function() {
             expect(scope.states).toBeDefined();
         });
+
+        it('must PATCH the employee when updating', inject(function($httpBackend) {
+            scope.saveEntity();
+            $httpBackend.expectPATCH('api/employees/0');
+            $httpBackend.flush();
+        }));
     });
 });

--- a/test/modules/trackr/administration/employees/editControllerSpec.js
+++ b/test/modules/trackr/administration/employees/editControllerSpec.js
@@ -1,11 +1,11 @@
 define(['baseTestSetup'], function(baseTestSetup) {
     'use strict';
-    describe('trackr.administration.controllers.employees.edit', function () {
+    describe('trackr.administration.employees.editController', function () {
         var EditController, scope;
         baseTestSetup();
         beforeEach(inject(function($rootScope, $controller) {
             scope = $rootScope.$new();
-            EditController = $controller('trackr.administration.controllers.employees.edit', {
+            EditController = $controller('trackr.administration.employees.editController', {
                 $scope: scope,
                 'createOrUpdateModal.userdata': {
                     employee: {

--- a/test/modules/trackr/administration/employees/listControllerSpec.js
+++ b/test/modules/trackr/administration/employees/listControllerSpec.js
@@ -1,6 +1,6 @@
 define(['baseTestSetup', 'angular'], function(baseTestSetup, angular) {
     'use strict';
-    describe('trackr.administration.controllers.employees.list', function() {
+    describe('trackr.administration.employees.listController', function() {
         var ListController, scope, state;
         baseTestSetup();
         beforeEach(inject(function($controller, $rootScope) {
@@ -9,7 +9,7 @@ define(['baseTestSetup', 'angular'], function(baseTestSetup, angular) {
                 go: angular.noop
             };
             spyOn(state, 'go');
-            ListController = $controller('trackr.administration.controllers.employees.list', {
+            ListController = $controller('trackr.administration.employees.listController', {
                 $scope: scope,
                 $state: state
             });

--- a/test/modules/trackr/administration/employees/newControllerSpec.js
+++ b/test/modules/trackr/administration/employees/newControllerSpec.js
@@ -1,12 +1,12 @@
 define(['baseTestSetup', 'angular'], function(baseTestSetup, angular) {
     'use strict';
-    describe('trackr.administration.controllers.employees.new', function() {
+    describe('trackr.administration.employees.listController', function() {
         var NewController, scope;
         baseTestSetup();
         beforeEach(inject(function($controller, $rootScope) {
             scope = $rootScope.$new();
             scope.closeModal = angular.noop;
-            NewController = $controller('trackr.administration.controllers.employees.new', {
+            NewController = $controller('trackr.administration.employees.newController', {
                 $scope: scope
             });
         }));

--- a/test/modules/trackr/employee/selfControllerSpec.js
+++ b/test/modules/trackr/employee/selfControllerSpec.js
@@ -22,15 +22,10 @@ define(['baseTestSetup'], function(baseTestSetup) {
         }));
 
         it('should load the employee from via the API', inject(function($httpBackend) {
-            $httpBackend.expectGET('api/employees/1');
+            $httpBackend.expectGET('api/employees/1/self');
             $httpBackend.flush();
             expect(scope.employee).toBeDefined();
         }));
 
-        it('updateEmployee should patch the employee via the self API method', inject(function($httpBackend) {
-            scope.updateEmployee({});
-            $httpBackend.expectPATCH('api/employees/1/self');
-            $httpBackend.flush();
-        }));
     });
 });

--- a/test/modules/trackr/employee/selfEditControllerSpec.js
+++ b/test/modules/trackr/employee/selfEditControllerSpec.js
@@ -1,0 +1,24 @@
+define(['baseTestSetup', 'angular'], function(baseTestSetup, angular) {
+    'use strict';
+    describe('trackr.employee.controllers.self-edit', function() {
+        var SelfEditController, scope;
+
+        baseTestSetup();
+        beforeEach(inject(function($rootScope, $controller) {
+            scope = $rootScope.$new();
+            scope.closeModal = angular.noop;
+            var userdata = {id: 0, firstName: 'firstName', lastName: 'lastName'};
+            SelfEditController = $controller('trackr.employee.controllers.self-edit', {
+                $scope: scope,
+                'createOrUpdateModal.userdata': userdata
+            });
+        }));
+
+        it('must update the employee via PUT', inject(function($httpBackend) {
+            scope.saveEntity();
+            $httpBackend.expectPUT('api/employees/0/self');
+            $httpBackend.flush();
+        }));
+    });
+
+});


### PR DESCRIPTION
Add the employee address to the following locations:
* Self editing (logic to create or update is in the REST service)
* Address book
* Administration (logic to create or update is in the frontend)

Refactored the administration of employees into a submodule.

Updating of SelfEmployees is now via PUT instead of PATCH.