### PR TITLE
Library upgrades (Angular 1.4, Angular-Ui-Bootstrap, Restangular)

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -7,7 +7,7 @@ require.config({
         'angular-l10n-de': 'vendor/angular-i18n/angular-locale_de-de',
         'angular-ui-router': 'vendor/angular-ui-router/release/angular-ui-router',
         'restangular': 'vendor/restangular/dist/restangular',
-        'lodash': 'vendor/lodash/dist/lodash',
+        'lodash': 'vendor/lodash/lodash',
         'angular-translate': 'vendor/angular-translate/angular-translate',
         'angular-translate-loader-url': 'vendor/angular-translate-loader-url/angular-translate-loader-url',
         'angular-ui': 'vendor/angular-ui-bootstrap-bower/ui-bootstrap-tpls',

--- a/bootstrap.prod.js
+++ b/bootstrap.prod.js
@@ -6,7 +6,7 @@ require.config({
         'angular-l10n-de': 'src/vendor/angular-i18n/angular-locale_de-de',
         'angular-ui-router': 'src/vendor/angular-ui-router/release/angular-ui-router.min',
         'restangular': 'src/vendor/restangular/dist/restangular.min',
-        'lodash': 'src/vendor/lodash/dist/lodash.min',
+        'lodash': 'src/vendor/lodash/lodash.min',
         'angular-translate': 'src/vendor/angular-translate/angular-translate.min',
         'angular-translate-loader-url': 'src/vendor/angular-translate-loader-url/angular-translate-loader-url.min',
         'angular-ui': 'src/vendor/angular-ui-bootstrap-bower/ui-bootstrap-tpls.min',

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
     "bootstrap": "3.2.0",
     "angular": "1.4.8",
     "requirejs": "2.1.14",
-    "restangular": "1.4.0",
+    "restangular": "1.5.1",
     "angular-ui-router": "0.2.10",
     "jquery": "git://github.com/jquery/jquery.git#2.1.1",
     "angular-translate": "~2.2.0",

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "angular-ui-router": "0.2.10",
     "jquery": "git://github.com/jquery/jquery.git#2.1.1",
     "angular-translate": "~2.2.0",
-    "angular-ui-bootstrap-bower": "~0.11.0",
+    "angular-ui-bootstrap-bower": "0.14.3",
     "angular-translate-loader-url": "2.2.0",
     "moment": "~2.8.1",
     "angular-i18n": "1.4.8",

--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "bootstrap": "3.2.0",
-    "angular": "1.2.22",
+    "angular": "1.4.8",
     "requirejs": "2.1.14",
     "restangular": "1.4.0",
     "angular-ui-router": "0.2.10",
@@ -28,14 +28,14 @@
     "angular-ui-bootstrap-bower": "~0.11.0",
     "angular-translate-loader-url": "2.2.0",
     "moment": "~2.8.1",
-    "angular-i18n": "~1.2.22",
+    "angular-i18n": "1.4.8",
     "chartjs": "~1.0.2",
     "randomColor": "~0.2.0"
   },
   "devDependencies": {
-    "angular-mocks": "1.2.22"
+    "angular-mocks": "1.4.8"
   },
   "resolutions": {
-    "angular": "1.2.22"
+    "angular": "1.4.8"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -6,7 +6,7 @@ define(['angular', 'jQuery', 'restangular', 'angular-ui-router', 'angular-ui', '
     var configFn = ['ui.router', 'ui.bootstrap', 'base', 'trackr', 'reportr', 'restangular', 'invoices', 'shared', 'pascalprecht.translate'];
     var app = angular.module('app', configFn);
 
-    app.config(['RestangularProvider', '$locationProvider', 'paginationConfig', '$httpProvider', '$translateProvider',
+    app.config(['RestangularProvider', '$locationProvider', 'uibPaginationConfig', '$httpProvider', '$translateProvider',
         function(RestangularProvider, $locationProvider, paginationConfig, $httpProvider, $translateProvider) {
             $translateProvider.useUrlLoader('api/translations');
 

--- a/src/modules/base/controllers/confirmationDialogController.js
+++ b/src/modules/base/controllers/confirmationDialogController.js
@@ -1,6 +1,6 @@
 define([], function() {
     'use strict';
-    return ['$scope', 'translationCode', '$modalInstance', function($scope, translationCode, $modalInstance) {
+    return ['$scope', 'translationCode', '$uibModalInstance', function($scope, translationCode, $modalInstance) {
         $scope.translationCode = translationCode;
 
         $scope.cancel = function() {

--- a/src/modules/base/services/confirmationDialogService.js
+++ b/src/modules/base/services/confirmationDialogService.js
@@ -1,6 +1,6 @@
 define([], function() {
     'use strict';
-    return ['$modal', function($modal) {
+    return ['$uibModal', function($modal) {
         return {
             /**
              * Opens a confirmation dialog with the buttons ok/cancel and the text translated by the translate code.

--- a/src/modules/invoices/index.tpl.html
+++ b/src/modules/invoices/index.tpl.html
@@ -9,8 +9,8 @@
     </div>
 </div>
 
-<tabset>
-    <tab ng-repeat="state in states">
+<uib-tabset>
+    <uib-tab ng-repeat="state in states">
         <tab-heading>
             <span translate="{{'INVOICE.' + state}}"></span> <span class="badge">{{invoices[state].page.totalElements}}</span>
         </tab-heading>
@@ -46,10 +46,10 @@
             </tr>
             </tbody>
         </table>
-        <pagination class="pagination-sm" total-items="invoices[state].page.totalElements" ng-model="invoices[state].page.number" items-per-page="invoices[state].page.size"
-                    ng-change="setPage(state)" max-size="5"></pagination>
-    </tab>
-</tabset>
+        <uib-pagination class="pagination-sm" total-items="invoices[state].page.totalElements" ng-model="invoices[state].page.number" items-per-page="invoices[state].page.size"
+                    ng-change="setPage(state)" max-size="5"></uib-pagination>
+    </uib-tab>
+</uib-tabset>
 
 <button type="button" class="btn btn-default" ng-click="addNew()">
     <span class="glyphicon glyphicon-plus"></span> <span translate="ACTIONS.NEW"></span>

--- a/src/modules/invoices/indexController.js
+++ b/src/modules/invoices/indexController.js
@@ -176,7 +176,11 @@ define(['modules/shared/PaginationLoader'], function(PaginationLoader) {
              * @param invoice Invoice to mark.
              */
             $scope.markPaid = function(invoice) {
-                $http.post('api/invoices/' + invoice.id + '/markPaid').then(function() {
+                $http({
+                    method: 'POST',
+                    url: 'api/invoices/' + invoice.id + '/markPaid',
+                    transformResponse: [] // Server returns 'Ok.', for now we don't want angular to parse this as JSON.
+                }).then(function() {
                     controller.refreshPage(invoice.invoiceState);
                     controller.refreshPage('PAID');
                 });

--- a/src/modules/invoices/newOrEdit.tpl.html
+++ b/src/modules/invoices/newOrEdit.tpl.html
@@ -7,7 +7,7 @@
         <div class="col-sm-6">
             <input type="text" class="form-control" id="debitor" autocomplete="off"
                    ng-model="invoice.debitor"
-                   typeahead="company as company.name for company in getCompanies($viewValue)"
+                   uib-typeahead="company as company.name for company in getCompanies($viewValue)"
                    typeahead-editable="false"
                    typeahead-min-length="1" />
         </div>
@@ -17,7 +17,7 @@
         <label class="form-label col-sm-3" for="creationDate" translate="INVOICE.CREATION_DATE"></label>
         <div class="input-group col-sm-6">
             <input type="text" id="creationDate" class="form-control" ng-model="invoice.creationDate"
-                   datepicker-popup="yyyy-MM-dd"
+                   uib-datepicker-popup="yyyy-MM-dd"
                    is-open="ctrl.creationDateOpened"
                    datepicker-options="dateOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"
@@ -36,7 +36,7 @@
         <label class="form-label col-sm-3" for="dueDate" translate="INVOICE.DUE_DATE"></label>
         <div class="input-group col-sm-6">
             <input type="text" id="dueDate" class="form-control" ng-model="invoice.dueDate"
-                   datepicker-popup="yyyy-MM-dd"
+                   uib-datepicker-popup="yyyy-MM-dd"
                    is-open="ctrl.dueDateOpened"
                    datepicker-options="dateOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"

--- a/src/modules/shared/controllers/createOrUpdateModalController.js
+++ b/src/modules/shared/controllers/createOrUpdateModalController.js
@@ -6,7 +6,7 @@ define([], function() {
      * Expects a "child"-controller name that will be instantiated after the basic setup of the scope. The child controller will get the scope of this
      * controller injected and thus can override any methods. It also gets the userdata injected.
      */
-    return ['$scope', '$modalInstance', 'controllerName', '$controller', 'templateName', 'createOrUpdateModal.userdata', 'titleTranslateCode',
+    return ['$scope', '$uibModalInstance', 'controllerName', '$controller', 'templateName', 'createOrUpdateModal.userdata', 'titleTranslateCode',
         function($scope, $modalInstance, controllerName, $controller, templateName, userdata, titleTranslateCode) {
             $scope.errors = [];
 

--- a/src/modules/shared/partials/dateInterval.tpl.html
+++ b/src/modules/shared/partials/dateInterval.tpl.html
@@ -4,7 +4,7 @@
         <div class="input-group">
             <input type="text" id="dateIntervalStartDate" class="form-control" ng-model="dateIntervalStart"
                    ng-change="dateIntervalDateChange()"
-                   datepicker-popup="yyyy-MM-dd"
+                   uib-datepicker-popup="yyyy-MM-dd"
                    is-open="dateIntervalStartOpened"
                    datepicker-options="dateIntervalOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"
@@ -24,7 +24,7 @@
         <div class="input-group">
             <input type="text" id="dateIntervalEndDate" class="form-control" ng-model="dateIntervalEnd"
                    ng-change="dateIntervalDateChange()"
-                   datepicker-popup="yyyy-MM-dd"
+                   uib-datepicker-popup="yyyy-MM-dd"
                    is-open="dateIntervalEndOpened"
                    datepicker-options="dateIntervalOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"

--- a/src/modules/shared/partials/inlineDatepicker.tpl.html
+++ b/src/modules/shared/partials/inlineDatepicker.tpl.html
@@ -1,6 +1,6 @@
 <div class="input-group">
 <input type="text" class="form-control" ng-model="model"
-       datepicker-popup="yyyy-MM-dd"
+       uib-datepicker-popup="yyyy-MM-dd"
        is-open="opened"
        datepicker-options="dateOptions"
        close-text="{{ 'ACTIONS.CLOSE' | translate }}"

--- a/src/modules/shared/services/createOrUpdateModalService.js
+++ b/src/modules/shared/services/createOrUpdateModalService.js
@@ -1,6 +1,6 @@
 define(['lodash'], function(_) {
     'use strict';
-    return ['$modal', function($modal) {
+    return ['$uibModal', function($modal) {
         return {
             /**
              * Opens a modal dialog. Uses the 'shared.controllers.create-or-update-modal' that will call '$controller(controllerName)' at its end, thus instantiating

--- a/src/modules/trackr/administration/companies/list.tpl.html
+++ b/src/modules/trackr/administration/companies/list.tpl.html
@@ -24,7 +24,7 @@
             <footer class="table-footer">
                 <div class="row">
                     <div class="col-lg-12 text-right pagination-container">
-                        <pagination class="pagination-sm" total-items="companies.page.totalElements" ng-model="companies.page.number" items-per-page="companies.page.size" ng-change="setPage()"></pagination>
+                        <uib-pagination class="pagination-sm" total-items="companies.page.totalElements" ng-model="companies.page.number" items-per-page="companies.page.size" ng-change="setPage()"></uib-pagination>
                     </div>
                 </div>
             </footer>

--- a/src/modules/trackr/administration/employees/list.tpl.html
+++ b/src/modules/trackr/administration/employees/list.tpl.html
@@ -24,8 +24,8 @@
             <footer class="table-footer">
                 <div class="row">
                     <div class="col-lg-12 text-right pagination-container">
-                        <pagination class="pagination-sm" total-items="employees.page.totalElements" ng-model="employees.page.number" items-per-page="employees.page.size"
-                                    ng-change="setPage()"></pagination>
+                        <uib-pagination class="pagination-sm" total-items="employees.page.totalElements" ng-model="employees.page.number" items-per-page="employees.page.size"
+                                    ng-change="setPage()"></uib-pagination>
                     </div>
                 </div>
             </footer>

--- a/src/modules/trackr/administration/employees/newOrEdit.tpl.html
+++ b/src/modules/trackr/administration/employees/newOrEdit.tpl.html
@@ -20,7 +20,7 @@
         <label class="form-label col-sm-4" for="joinDate" translate="EMPLOYEE.JOIN_DATE"></label>
         <div class="input-group col-sm-6">
             <input type="text" id="joinDate" class="form-control" ng-model="employee.joinDate"
-                   datepicker-popup="yyyy-MM-dd"
+                   uib-datepicker-popup="yyyy-MM-dd"
                    is-open="ctrl.joinDateOpened"
                    datepicker-options="dateOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"
@@ -40,7 +40,7 @@
         <div class="input-group col-sm-6">
             <input type="text" id="leaveDate" class="form-control" ng-model="employee.leaveDate"
                    ng-change="leaveDateChange(employee.leaveDate)"
-                   datepicker-popup="yyyy-MM-dd"
+                   uib-datepicker-popup="yyyy-MM-dd"
                    is-open="ctrl.leaveDateOpened"
                    datepicker-options="dateOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"

--- a/src/modules/trackr/administration/projects/list.tpl.html
+++ b/src/modules/trackr/administration/projects/list.tpl.html
@@ -25,7 +25,7 @@
             <footer class="table-footer">
                 <div class="row">
                     <div class="col-lg-12 text-right pagination-container">
-                        <pagination class="pagination-sm" total-items="projects.page.totalElements" ng-model="projects.page.number" items-per-page="projects.page.size" ng-change="setPage()"></pagination>
+                        <uib-pagination class="pagination-sm" total-items="projects.page.totalElements" ng-model="projects.page.number" items-per-page="projects.page.size" ng-change="setPage()"></uib-pagination>
                     </div>
                 </div>
             </footer>

--- a/src/modules/trackr/administration/projects/newOrEdit.tpl.html
+++ b/src/modules/trackr/administration/projects/newOrEdit.tpl.html
@@ -11,7 +11,7 @@
         <div class="col-sm-6">
             <input type="text" class="form-control" id="company" autocomplete="off"
                    ng-model="project.company"
-                   typeahead="company as company.name for company in getCompanies($viewValue)"
+                   uib-typeahead="company as company.name for company in getCompanies($viewValue)"
                    typeahead-editable="false"
                    typeahead-min-length="1" />
         </div>
@@ -22,7 +22,7 @@
         <div class="col-sm-6">
             <input type="text" class="form-control" id="debitor" autocomplete="off"
                    ng-model="project.debitor"
-                   typeahead="company as company.name for company in getCompanies($viewValue)"
+                   uib-typeahead="company as company.name for company in getCompanies($viewValue)"
                    typeahead-editable="false"
                    typeahead-min-length="1" />
         </div>

--- a/src/modules/trackr/employee/address_book/address_book.tpl.html
+++ b/src/modules/trackr/employee/address_book/address_book.tpl.html
@@ -32,4 +32,4 @@
     </tr>
 </table>
 
-<pagination class="pagination-sm" total-items="employees.page.totalElements" ng-model="employees.page.number" items-per-page="employees.page.size" ng-change="setPage()"></pagination>
+<uib-pagination class="pagination-sm" total-items="employees.page.totalElements" ng-model="employees.page.number" items-per-page="employees.page.size" ng-change="setPage()"></uib-pagination>

--- a/src/modules/trackr/employee/expenses/expense-edit.tpl.html
+++ b/src/modules/trackr/employee/expenses/expense-edit.tpl.html
@@ -13,7 +13,7 @@
         <label class="form-label col-sm-2" for="fromDate" translate="TRAVEL_EXPENSE.FROM_DATE"></label>
         <div class="input-group col-sm-6">
             <input type="text" id="fromDate" class="form-control" ng-model="expense.fromDate"
-                   datepicker-popup="yyyy-MM-dd"
+                   uib-datepicker-popup="yyyy-MM-dd"
                    is-open="ctrl.fromDateOpened"
                    datepicker-options="dateOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"
@@ -32,7 +32,7 @@
         <label class="form-label col-sm-2" for="toDate" translate="TRAVEL_EXPENSE.TO_DATE"></label>
         <div class="input-group col-sm-6">
             <input type="text" id="toDate" class="form-control" ng-model="expense.toDate"
-                   datepicker-popup="yyyy-MM-dd"
+                   uib-datepicker-popup="yyyy-MM-dd"
                    is-open="ctrl.toDateOpened"
                    datepicker-options="dateOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"

--- a/src/modules/trackr/employee/expenses/expenseEditController.js
+++ b/src/modules/trackr/employee/expenses/expenseEditController.js
@@ -34,7 +34,7 @@ define(['lodash'], function(_) {
         $scope.openDate = function($event, name) {
             $event.stopPropagation();
             $event.preventDefault();
-            controller[name] = true;
+            controller[name] = !controller[name];
         };
 
         $scope.dateOptions = {

--- a/src/modules/trackr/employee/expenses/expenseNewController.js
+++ b/src/modules/trackr/employee/expenses/expenseNewController.js
@@ -35,7 +35,7 @@ define([], function () {
         $scope.openDate = function($event, name) {
             $event.stopPropagation();
             $event.preventDefault();
-            controller[name] = true;
+            controller[name] = !controller[name];
         };
 
         $scope.dateOptions = {

--- a/src/modules/trackr/employee/expenses/list.tpl.html
+++ b/src/modules/trackr/employee/expenses/list.tpl.html
@@ -1,5 +1,5 @@
-<tabset>
-    <tab ng-repeat="state in states">
+<uib-tabset>
+    <uib-tab ng-repeat="state in states">
         <tab-heading>
             <span translate="{{'TRAVEL_EXPENSE_REPORT.' + state}}"></span> <span class="badge">{{reports[state].page.totalElements}}</span>
         </tab-heading>
@@ -27,8 +27,8 @@
             </tr>
             </tbody>
         </table>
-        <pagination class="pagination-sm" total-items="reports[state].page.totalElements" ng-model="reports[state].page.number" items-per-page="reports[state].page.size"
-                    ng-change="setPage(state)" max-size="5"></pagination>
-    </tab>
-</tabset>
+        <uib-pagination class="pagination-sm" total-items="reports[state].page.totalElements" ng-model="reports[state].page.number" items-per-page="reports[state].page.size"
+                    ng-change="setPage(state)" max-size="5"></uib-pagination>
+    </uib-tab>
+</uib-tabset>
 <button ng-click="addNew()" type="button" class="btn btn-primary" translate="ACTIONS.NEW"></button>

--- a/src/modules/trackr/employee/expenses/report-new.tpl.html
+++ b/src/modules/trackr/employee/expenses/report-new.tpl.html
@@ -2,7 +2,7 @@
     <input type="text" class="form-control" autocomplete="off"
            ng-model="ctrl.company"
            typeahead-on-select="loadProjects(ctrl.company)"
-           typeahead="company as company.name for company in getCompanies($viewValue)"
+           uib-typeahead="company as company.name for company in getCompanies($viewValue)"
            typeahead-editable="false"
            typahead-min-length="1"
            placeholder="{{ 'TRAVEL_EXPENSE_REPORT.DEBITOR' | translate }}"/>
@@ -10,7 +10,7 @@
 <div class="form-group">
     <input type="text" class="form-control" autocomplete="off"
            ng-model="ctrl.project"
-           typeahead="project as project.name for project in projects | filter:{name:$viewValue}"
+           uib-typeahead="project as project.name for project in projects | filter:{name:$viewValue}"
            typeahead-editable="false"
            typahead-min-length="1"
            placeholder="{{ 'TRAVEL_EXPENSE_REPORT.PROJECT' | translate }} ({{ 'FIELDS.OPTIONAL' | translate }})"/>

--- a/src/modules/trackr/employee/sick_days/sick-days-edit.tpl.html
+++ b/src/modules/trackr/employee/sick_days/sick-days-edit.tpl.html
@@ -3,8 +3,8 @@
         <label class="form-label col-sm-4" for="startDate" translate="SICK_DAYS.START_DATE"></label>
         <div class="input-group col-sm-6">
             <input type="text" id="startDate" class="form-control" ng-model="sickDays.startDate"
-                   datepicker-popup="yyyy-MM-dd"
-                   is-open="$parent.$parent.startDateOpened"
+                   uib-datepicker-popup="yyyy-MM-dd"
+                   is-open="startDateOpened"
                    datepicker-options="dateOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"
                    current-text="{{ 'DATE.TODAY' | translate }}"
@@ -22,8 +22,8 @@
         <label class="form-label col-sm-4" for="endDate" translate="SICK_DAYS.END_DATE"></label>
         <div class="input-group col-sm-6">
             <input type="text" id="endDate" class="form-control" ng-model="sickDays.endDate"
-                   datepicker-popup="yyyy-MM-dd"
-                   is-open="$parent.$parent.endDateOpened"
+                   uib-datepicker-popup="yyyy-MM-dd"
+                   is-open="endDateOpened"
                    datepicker-options="dateOptions"
                    close-text="{{ 'ACTIONS.CLOSE' | translate }}"
                    current-text="{{ 'DATE.TODAY' | translate }}"

--- a/src/modules/trackr/employee/sick_days/sickDaysEditController.js
+++ b/src/modules/trackr/employee/sick_days/sickDaysEditController.js
@@ -11,7 +11,7 @@ define(['lodash', 'moment'], function(_, moment) {
         $scope.openDate = function(event, name) {
             event.stopPropagation();
             event.preventDefault();
-            $scope[name] = true;
+            $scope[name] = !$scope[name];
         };
 
         controller.onError = function(response) {

--- a/src/modules/trackr/employee/timesheet/timesheet.tpl.html
+++ b/src/modules/trackr/employee/timesheet/timesheet.tpl.html
@@ -8,7 +8,7 @@
                 <div class="col-sm-4">
                     <input type="text" class="form-control" id="project" autocomplete="off"
                            ng-model="project"
-                           typeahead="project as getProjectLabel(project) for project in getProjects($viewValue)"
+                           uib-typeahead="project as getProjectLabel(project) for project in getProjects($viewValue)"
                            typeahead-editable="false"
                            typeahead-min-length="1" />
                 </div>
@@ -22,14 +22,14 @@
             <div class="form-group">
                 <label class="form-label col-sm-2" for="startTime" translate="WORKTIME.START"></label>
                 <div ng-model="startTime" id="startTime" style="display:inline-block;" class="col-sm-6">
-                    <timepicker hour-step="1" minute-step="15" show-meridian="ismeridian"></timepicker>
+                    <uib-timepicker hour-step="1" minute-step="15" show-meridian="ismeridian"></uib-timepicker>
                 </div>
             </div>
 
             <div class="form-group">
                 <label class="form-label col-sm-2" for="endTime" translate="WORKTIME.END"></label>
                 <div ng-model="endTime" id="endTime" style="display:inline-block;" class="col-sm-6">
-                    <timepicker hour-step="1" minute-step="15" show-meridian="ismeridian"></timepicker>
+                    <uib-timepicker hour-step="1" minute-step="15" show-meridian="ismeridian"></uib-timepicker>
                 </div>
             </div>
 

--- a/src/modules/trackr/employee/timesheet/timesheetOverview.tpl.html
+++ b/src/modules/trackr/employee/timesheet/timesheetOverview.tpl.html
@@ -1,4 +1,4 @@
-<datepicker ng-model="month" datepicker-mode="datepickerMode" min-mode="month" ng-change="monthChange()"/>
+<uib-datepicker ng-model="month" datepicker-mode="datepickerMode" min-mode="'month'" ng-change="monthChange()"></uib-datepicker>
 <div class="form-group">
     <label class="control-label" for="hoursPerDay" translate="PAGES.EMPLOYEE.TIMESHEET_OVERVIEW.HOURS_PER_DAY"></label>
     <input id="hoursPerDay" class="form-control" style="width: 100px;" type="text" placeholder="{{ 'PAGES.EMPLOYEE.TIMESHEET_OVERVIEW.HOURS_PER_DAY' | translate }}" ng-model="hoursPerDay"/>

--- a/src/modules/trackr/employee/vacation/new.tpl.html
+++ b/src/modules/trackr/employee/vacation/new.tpl.html
@@ -1,13 +1,13 @@
-<form action="" ng-submit="submitVacationRequest(vacationRequest)">
+<form ng-submit="submitVacationRequest(vacationRequest)">
     <div class="row" error-display="startDate">
         <div class="col-sm-4">
             <div class="well well-sm" ng-model="vacationRequest.startDate">
-                <datepicker starting-day="1"></datepicker>
+                <uib-datepicker starting-day="1"></uib-datepicker>
             </div>
         </div>
         <div class="col-sm-4" error-display="endDate">
             <div class="well well-sm" ng-model="vacationRequest.endDate">
-                <datepicker starting-day="1"></datepicker>
+                <uib-datepicker starting-day="1"></uib-datepicker>
             </div>
         </div>
     </div>

--- a/src/modules/trackr/supervisor/billReport.tpl.html
+++ b/src/modules/trackr/supervisor/billReport.tpl.html
@@ -7,7 +7,7 @@
         <input type="text" class="form-control" autocomplete="off"
                ng-model="company"
                typeahead-on-select="loadProjects(company)"
-               typeahead="company as company.name for company in getCompanies($viewValue)"
+               uib-typeahead="company as company.name for company in getCompanies($viewValue)"
                typeahead-editable="false"
                typahead-min-length="1"
                placeholder="{{ 'PROJECT.COMPANY' |translate }}"/>
@@ -16,7 +16,7 @@
         <input type="text" class="form-control" autocomplete="off"
                ng-model="project"
                typeahead-on-select="loadProjectData()"
-               typeahead="project as project.name for project in projects | filter:{name:$viewValue}"
+               uib-typeahead="project as project.name for project in projects | filter:{name:$viewValue}"
                typeahead-editable="false"
                typahead-min-length="1"
                placeholder="{{ 'PROJECT.PROJECT' |translate }}"/>
@@ -44,15 +44,15 @@
         </table>
     </div>
 
-    <tabset>
-        <tab ng-repeat="(employee, minutes) in employeeMapping" heading="{{employee}}">
+    <uib-tabset>
+        <uib-tab ng-repeat="(employee, minutes) in employeeMapping" heading="{{employee}}">
             <table class="table table-condensed table-bordered">
                 <tr><td translate="PAGES.SUPERVISOR.BILL_CREATE.HOURS"></td><td>{{minutes / 60}} h</td></tr>
                 <tr><td translate="PAGES.SUPERVISOR.BILL_CREATE.MAN_DAYS"></td><td>{{(minutes / 60) / 8}} d</td></tr>
                 <tr><td translate="PAGES.SUPERVISOR.BILL_CREATE.NET_PRICE"></td><td>{{(minutes / 60) * project.hourlyRate | currency }}</td></tr>
                 <tr><td translate="PAGES.SUPERVISOR.BILL_CREATE.GROSS_PRICE"></td><td>{{(minutes / 60) * project.hourlyRate * 1.19 | currency}}</td></tr>
             </table>
-        </tab>
-    </tabset>
+        </uib-tab>
+    </uib-tabset>
 
 </div>

--- a/src/modules/trackr/supervisor/expenses/edit.tpl.html
+++ b/src/modules/trackr/supervisor/expenses/edit.tpl.html
@@ -15,7 +15,7 @@
         <input type="text" class="form-control" autocomplete="off"
                ng-model="report.debitor"
                typeahead-on-select="selectCompany(report.debitor)"
-               typeahead="company as company.name for company in getCompanies($viewValue)"
+               uib-typeahead="company as company.name for company in getCompanies($viewValue)"
                typeahead-editable="false"
                typahead-min-length="1"
                placeholder="{{ 'TRAVEL_EXPENSE_REPORT.DEBITOR' | translate }}"/>
@@ -24,7 +24,7 @@
         <input type="text" class="form-control" autocomplete="off"
                ng-model="report.project"
                typeahead-on-select="selectProject(report.project)"
-               typeahead="project as project.name for project in projects | filter:{name:$viewValue}"
+               uib-typeahead="project as project.name for project in projects | filter:{name:$viewValue}"
                typeahead-editable="false"
                typahead-min-length="1"
                placeholder="{{ 'TRAVEL_EXPENSE_REPORT.PROJECT' | translate }} ({{ 'FIELDS.OPTIONAL' | translate }})"/>

--- a/src/modules/trackr/supervisor/expenses/list.tpl.html
+++ b/src/modules/trackr/supervisor/expenses/list.tpl.html
@@ -8,8 +8,8 @@
     <button type="submit" class="btn btn-primary" translate="ACTIONS.GO"></button>
 </form>
 <br />
-<tabset>
-    <tab ng-repeat="state in states">
+<uib-tabset>
+    <uib-tab ng-repeat="state in states">
         <tab-heading>
             <span translate="{{'TRAVEL_EXPENSE_REPORT.' + state}}"></span> <span class="badge">{{reports[state].page.totalElements}}</span>
         </tab-heading>
@@ -39,7 +39,7 @@
             </tr>
             </tbody>
         </table>
-        <pagination class="pagination-sm" total-items="reports[state].page.totalElements" ng-model="reports[state].page.number" items-per-page="reports[state].page.size"
-                    ng-change="setPage(state)" max-size="5"></pagination>
-    </tab>
-</tabset>
+        <uib-pagination class="pagination-sm" total-items="reports[state].page.totalElements" ng-model="reports[state].page.number" items-per-page="reports[state].page.size"
+                    ng-change="setPage(state)" max-size="5"></uib-pagination>
+    </uib-tab>
+</uib-tabset>

--- a/src/modules/trackr/supervisor/fileBillableHours.tpl.html
+++ b/src/modules/trackr/supervisor/fileBillableHours.tpl.html
@@ -7,7 +7,7 @@
         <input type="text" class="form-control" autocomplete="off"
                ng-model="project"
                typeahead-on-select="loadWorktimes()"
-               typeahead="project as getProjectLabel(project) for project in getProjects($viewValue)"
+               uib-typeahead="project as getProjectLabel(project) for project in getProjects($viewValue)"
                typeahead-editable="false"
                typeahead-min-length="1"
                placeholder="{{ 'PROJECT.PROJECT' |translate }}"/>
@@ -22,44 +22,46 @@
     </div>
 
     <div class="col-lg-12">
-        <tabset>
-            <tab ng-repeat="(id, employee) in employeeMapping" heading="{{employee.name}}" ng-controller="trackr.supervisor.controllers.save-billable-hours">
-                <table class="table table-condensed table-bordered">
-                    <tr>
-                        <th translate="BILLABLE_TIME.DATE"></th>
-                        <th translate="WORKTIME.COMMENT"></th>
-                        <th translate="PAGES.SUPERVISOR.BILL.HOURS"></th>
-                        <th colspan="2" translate="BILLABLE_TIME.BILLABLE_HOURS"></th>
-                    </tr>
-                    <tr>
-                        <td colspan="3"></td>
-                        <td colspan="2" class="form-inline">
-                            <input class="form-control input-sm"
-                                   ng-change="setBillableHoursAll(billableHoursAll)"
-                                   ng-model="billableHoursAll" placeholder="{{ 'PAGES.SUPERVISOR.BILL.SET_ALL' | translate }}"/>
-                            <button type="button" class="btn btn-sm btn-primary"
-                                    ng-click="transferHours(employee)" translate="PAGES.SUPERVISOR.BILL.TRANSFER_HOURS"></button>
-                        </td>
-                    </tr>
-                    <tr ng-repeat="workTime in employee.workTimes">
-                        <td>{{workTime.date | date:'dd.MM.yyyy'}}</td>
-                        <td>{{workTime.comment}}</td>
-                        <td>{{workTime.enteredMinutes / 60}}</td>
-                        <td><input class="input-sm form-control" ng-model="workTime.hours" ng-change="recalculateBillableSum()"/></td>
-                        <td>
-                            <span ng-if="workTime.posted" class="glyphicon" ng-class="{'glyphicon-warning-sign': workTime.error, 'glyphicon-ok-sign': !workTime.error}"></span>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td colspan="2"><b translate="PAGES.SUPERVISOR.BILL.SUM"></b></td>
-                        <td>{{sumMinutes / 60}}</td>
-                        <td colspan="2">{{sumBillableHours}}</td>
-                    </tr>
-                </table>
-                <button type="button" class="btn btn-default" ng-click="createBill()" translate="ACTIONS.SAVE"></button>
-                <button type="button" class="btn btn-warning" ng-click="resetHours()" translate="ACTIONS.RESET"></button>
-            </tab>
-        </tabset>
+        <uib-tabset>
+            <uib-tab ng-repeat="(id, employee) in employeeMapping" heading="{{employee.name}}">
+                <div ng-controller="trackr.supervisor.controllers.save-billable-hours">
+                    <table class="table table-condensed table-bordered">
+                        <tr>
+                            <th translate="BILLABLE_TIME.DATE"></th>
+                            <th translate="WORKTIME.COMMENT"></th>
+                            <th translate="PAGES.SUPERVISOR.BILL.HOURS"></th>
+                            <th colspan="2" translate="BILLABLE_TIME.BILLABLE_HOURS"></th>
+                        </tr>
+                        <tr>
+                            <td colspan="3"></td>
+                            <td colspan="2" class="form-inline">
+                                <input class="form-control input-sm"
+                                       ng-change="setBillableHoursAll(billableHoursAll)"
+                                       ng-model="billableHoursAll" placeholder="{{ 'PAGES.SUPERVISOR.BILL.SET_ALL' | translate }}"/>
+                                <button type="button" class="btn btn-sm btn-primary"
+                                        ng-click="transferHours(employee)" translate="PAGES.SUPERVISOR.BILL.TRANSFER_HOURS"></button>
+                            </td>
+                        </tr>
+                        <tr ng-repeat="workTime in employee.workTimes">
+                            <td>{{workTime.date | date:'dd.MM.yyyy'}}</td>
+                            <td>{{workTime.comment}}</td>
+                            <td>{{workTime.enteredMinutes / 60}}</td>
+                            <td><input class="input-sm form-control" ng-model="workTime.hours" ng-change="recalculateBillableSum()"/></td>
+                            <td>
+                                <span ng-if="workTime.posted" class="glyphicon" ng-class="{'glyphicon-warning-sign': workTime.error, 'glyphicon-ok-sign': !workTime.error}"></span>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td colspan="2"><b translate="PAGES.SUPERVISOR.BILL.SUM"></b></td>
+                            <td>{{sumMinutes / 60}}</td>
+                            <td colspan="2">{{sumBillableHours}}</td>
+                        </tr>
+                    </table>
+                    <button type="button" class="btn btn-default" ng-click="createBill()" translate="ACTIONS.SAVE"></button>
+                    <button type="button" class="btn btn-warning" ng-click="resetHours()" translate="ACTIONS.RESET"></button>
+                </div>
+            </uib-tab>
+        </uib-tabset>
 
     </div>
 </div>

--- a/src/modules/trackr/supervisor/vacation/vacation.tpl.html
+++ b/src/modules/trackr/supervisor/vacation/vacation.tpl.html
@@ -29,8 +29,8 @@
             </tbody>
         </table>
 
-        <tabset>
-            <tab heading="{{ 'VACATION_REQUEST.APPROVED' | translate }}">
+        <uib-tabset>
+            <uib-tab heading="{{ 'VACATION_REQUEST.APPROVED' | translate }}">
                 <table class="table-bordered table table-condensed">
                     <thead>
                         <tr>
@@ -65,8 +65,8 @@
                         </tr>
                     </tbody>
                 </table>
-            </tab>
-            <tab heading="{{ 'VACATION_REQUEST.REJECTED' | translate }}">
+            </uib-tab>
+            <uib-tab heading="{{ 'VACATION_REQUEST.REJECTED' | translate }}">
                 <table class="table-bordered table table-condensed">
                     <thead>
                         <tr>
@@ -94,8 +94,8 @@
                         </tr>
                     </tbody>
                 </table>
-            </tab>
-        </tabset>
+            </uib-tab>
+        </uib-tabset>
 
     </div>
 </div>

--- a/test/test-main.js
+++ b/test/test-main.js
@@ -15,7 +15,7 @@ require.config({
         'angular-ui-router': 'vendor/angular-ui-router/release/angular-ui-router',
         'angular-mocks': 'vendor/angular-mocks/angular-mocks',
         'restangular':'vendor/restangular/dist/restangular',
-        'lodash': 'vendor/lodash/dist/lodash',
+        'lodash': 'vendor/lodash/lodash',
         'fixtures': '../test/fixtures',
         'baseTestSetup': '../test/baseTestSetup',
         'backendMock': '../test/backendMock',


### PR DESCRIPTION
Upgrades the libraries listed to new versions.

For Angular 1.4 some migrations were necessary
- Remove an empty `action=""` from a form to prevent submission.
- Remove response parsing for one HTTP POST call because the response is not JSON and not necessary.

For Restangular a migration was necessary
- The transitive lodash dependency now has new paths.

For Angular UI Bootstrap some migrations were necessary
- The directives and services now have a prefix (`uib-` and `uib` resp.). The old one still work but are deprecated.
- The `uib-tab` directive opens an isolate scope, thus a custom `ng-controller` had to be moved.

Some other bugs were found and fixed:
- Editing sick days is now possible.
- When adding/editing an expense the datepicker popups are closeable again.
