### PR TITLE
Makes the URL to techdev portal configurable

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,7 +78,8 @@ module.exports = function (grunt) {
                         'angular-ui': 'empty:',
                         'moment': 'empty:',
                         'chartjs': 'empty:',
-                        'randomColor': 'empty:'
+                        'randomColor': 'empty:',
+                        'configuration': 'empty:'
                     }
                 }
             }

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -13,7 +13,8 @@ require.config({
         'angular-ui': 'vendor/angular-ui-bootstrap-bower/ui-bootstrap-tpls',
         'moment': 'vendor/moment/moment',
         'chartjs': 'vendor/chartjs/Chart',
-        'randomColor': 'vendor/randomColor/randomColor'
+        'randomColor': 'vendor/randomColor/randomColor',
+        'configuration': 'conf/trackr'
     },
     shim: {
         'angular': { exports: 'angular', deps: ['jQuery'] },

--- a/bootstrap.prod.js
+++ b/bootstrap.prod.js
@@ -12,7 +12,8 @@ require.config({
         'angular-ui': 'src/vendor/angular-ui-bootstrap-bower/ui-bootstrap-tpls.min',
         'moment': 'src/vendor/moment/min/moment.min',
         'chartjs': 'src/vendor/chartjs/Chart.min',
-        'randomColor': 'src/vendor/randomColor/randomColor'
+        'randomColor': 'src/vendor/randomColor/randomColor',
+        'configuration': 'conf/trackr'
     },
     shim: {
         'angular': { exports: 'angular', deps: ['jQuery'] },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,6 +17,7 @@ module.exports = function (config) {
 
         // list of files / patterns to load in the browser
         files: [
+            {pattern: 'src/conf/*.js', included: false},
             {pattern: 'src/modules/**/*.js', included: false},
             {pattern: 'test/**/*Spec.js', included: false}, //I don't have any clue why it must be *Spec. TODO: find out.
             {pattern: 'test/fixtures.js', included: false},

--- a/src/conf/trackr.js
+++ b/src/conf/trackr.js
@@ -1,0 +1,5 @@
+define([], function () {
+    return {
+        "portalUrl": "http://localhost/portal"
+    }
+});

--- a/src/jiraIssueCollector.js
+++ b/src/jiraIssueCollector.js
@@ -1,4 +1,4 @@
-define(['jQuery'], function(jQuery) {
+define(['jQuery', 'configuration'], function(jQuery, config) {
     'use strict';
     return function() {
         function loadIssueCollector(url) {
@@ -10,15 +10,8 @@ define(['jQuery'], function(jQuery) {
             });
         }
 
-        jQuery.ajax({
-            url: 'conf/trackr.json',
-            type: 'get',
-            dataType: 'json',
-            success: function(response) {
-                if(response.jiraIssueCollectorUrl) {
-                    loadIssueCollector(response.jiraIssueCollectorUrl);
-                }
-            }
-        });
+        if(config.jiraIssueCollectorUrl) {
+            loadIssueCollector(config.jiraIssueCollectorUrl);
+        }
     };
 });

--- a/src/modules/base/base.js
+++ b/src/modules/base/base.js
@@ -1,16 +1,20 @@
 define([
     'angular',
-    'modules/base/controllers/controllers',
-    'modules/base/services/services',
-    'modules/base/directives/directives',
+    './controllers/controllers',
+    './services/services',
+    './directives/directives',
+    './filters/filters',
     'i18n',
-    'jiraIssueCollector'
-], function(angular, controllers, services, directives, i18n, issueCollector) {
+    'jiraIssueCollector',
+    'configuration'
+], function(angular, controllers, services, directives, filters, i18n, issueCollector, config) {
     'use strict';
     var base = angular.module('base', []);
     controllers.init(base);
     services.init(base);
     directives.init(base);
+    filters.init(base);
+    base.value('base.config', config);
 
     base.config(['$stateProvider', '$urlRouterProvider', function($stateProvider, $urlRouterProvider) {
         $urlRouterProvider.otherwise('/');
@@ -48,9 +52,7 @@ define([
                     'app.user': ['$rootScope', '$log', 'base.services.user', '$http', '$state', function($rootScope, $log, UserService, $http, $state) {
                         //Try to load the user. If the user cannot be loaded
                         return $http.get('api/principal').then(function(response) {
-                            if(response.data.fake !== true) {
-                                issueCollector();
-                            }
+                            issueCollector();
                             var user = response.data;
                             UserService.setUser(user);
                             enableStateAuthorization($rootScope, $log, UserService);

--- a/src/modules/base/filters/configValueFilter.js
+++ b/src/modules/base/filters/configValueFilter.js
@@ -1,0 +1,15 @@
+define([], function () {
+    'use strict';
+    function configValueFilter(configuration) {
+        return function (configKey) {
+            if (configuration.hasOwnProperty(configKey)) {
+                return configuration[configKey];
+            } else {
+                throw new Error('Configuration key ' + configKey + ' not found.');
+            }
+        };
+    }
+
+    configValueFilter.$inject = ['base.config'];
+    return configValueFilter;
+});

--- a/src/modules/base/filters/filters.js
+++ b/src/modules/base/filters/filters.js
@@ -1,0 +1,9 @@
+define(['./configValueFilter'], function (configValue) {
+    'use strict';
+
+    return {
+        init: function(module) {
+            module.filter('configValue', configValue);
+        }
+    };
+});

--- a/src/modules/base/partials/authorization.tpl.html
+++ b/src/modules/base/partials/authorization.tpl.html
@@ -9,7 +9,7 @@
                                 No authentication found. Please click the following link to authenticate.
                             </p>
                             <a class="btn btn-primary" target="_self"
-                               href="/portal/oauth/authorize?client_id=trackr-page&response_type=token&redirect_uri={{returnToUri}}">Authenticate
+                               href="{{ 'portalUrl' | configValue }}/oauth/authorize?client_id=trackr-page&response_type=token&redirect_uri={{returnToUri}}">Authenticate
                             </a>
                         </div>
                     </div>

--- a/test/backendMock.js
+++ b/test/backendMock.js
@@ -7,8 +7,7 @@ define(['fixtures'], function(fixtures) {
             enabled: true,
             authorities: [
                 {authority: 'ROLE_ADMIN'}
-            ],
-            fake: true
+            ]
         });
 
         /**

--- a/test/modules/base/filters/configValueFilterSpec.js
+++ b/test/modules/base/filters/configValueFilterSpec.js
@@ -1,0 +1,14 @@
+define(['baseTestSetup'], function(baseTestSetup) {
+    'use strict';
+    describe('base.filters.configValueFilter', function () {
+        baseTestSetup();
+
+        it('should parse a config key to a config value', inject(function(configValueFilter) {
+            expect(configValueFilter('portalUrl')).toBeDefined();
+        }));
+
+        it('should throw when a value does not exist', inject(function (configValueFilter) {
+            expect( function() { configValueFilter('totally_not_existing_key'); }).toThrow('Configuration key totally_not_existing_key not found.');
+        }));
+    });
+});

--- a/test/test-main.js
+++ b/test/test-main.js
@@ -22,12 +22,11 @@ require.config({
         'angular-translate': 'vendor/angular-translate/angular-translate',
         'angular-translate-loader-url': 'vendor/angular-translate-loader-url/angular-translate-loader-url',
         'angular-ui': 'vendor/angular-ui-bootstrap-bower/ui-bootstrap-tpls',
-        'angular-charts': 'vendor/angular-charts/dist/angular-charts',
         'moment': 'vendor/moment/moment',
-        'd3': 'vendor/d3/d3',
         'confirmationServiceMock': '../test/modules/base/services/confirmationServiceMock',
         'chartjs': 'vendor/chartjs/Chart',
-        'randomColor': 'vendor/randomColor/randomColor'
+        'randomColor': 'vendor/randomColor/randomColor',
+        'configuration': 'conf/trackr'
     },
     shim: {
         'angular': { exports: 'angular' },


### PR DESCRIPTION
This PR is needed for the move of trackr to `trackr.techdev.io`.

Since we're moving the portal to be on a different host the complete URL needs to be set and should be configurable (in authorization.tpl.html).

To allow that the config system of trackr was extended a bit. The configuration file now is a require.js module (makes it easier than to load a plain JSON
file which would require a plugin). It's provided as a value that can be injected anywhere in the app. A filter to render config values to templates is added.
The config file is excluded from the dist build since it needs to be different on different environments.

During development the config file needs to be in `src/conf/`, on environments it needs to be in `conf/` (see bootstrap.prod.js).

This also allowed removing one jQuery AJAX call from jiraIssueCollector.js and the removal of the `fake` marker in the backendMock.js (the config file is now loadable
in tests, before that it broke in base.js).

Also, some unused library references where removed from test-main.js.
