### PR TITLE
TRACKR-297 Compatible with Spring Boot 1.3 backend

### DIFF
--- a/src/modules/trackr/administration/companies/displayController.js
+++ b/src/modules/trackr/administration/companies/displayController.js
@@ -81,12 +81,11 @@ define(['lodash'], function(_) {
             /*
              Initialization of $scope objects
              */
-            Restangular.allUrl('companies', 'api/companies/search/findByCompanyId').getList({
+            Restangular.oneUrl('companies', 'api/companies/search/findByCompanyId').get({
                 companyId: $stateParams.id,
                 projection: 'withAddressAndContactPersons'
-            }).then(function(companies) {
-                //TODO: why does spring return an array? The method signature is a single entity.
-                $scope.company = companies[0];
+            }).then(function(company) {
+                $scope.company = company;
             });
         }];
 });

--- a/src/modules/trackr/administration/projects/displayController.js
+++ b/src/modules/trackr/administration/projects/displayController.js
@@ -6,12 +6,11 @@ define(['lodash'], function(_) {
             /*
              Initialization of $scope objects
              */
-            Restangular.allUrl('projects', 'api/projects/search/findByIdentifier').getList({
+            Restangular.oneUrl('projects', 'api/projects/search/findByIdentifier').get({
                 identifier: $stateParams.id,
                 projection: 'withCompanyAndDebitor'
-            }).then(function(projects) {
-                //TODO: why does spring return an array? The method signature is a single entity.
-                $scope.project = projects[0];
+            }).then(function(project) {
+                $scope.project = project;
             });
 
             $scope.showEditForm = function() {

--- a/src/modules/trackr/employee/expenses/listController.js
+++ b/src/modules/trackr/employee/expenses/listController.js
@@ -37,7 +37,7 @@ define(['modules/shared/PaginationLoader', 'lodash'], function(PaginationLoader,
         controller.loadPage = function(page, state, sort) {
             var params = {
                 projection: 'overview',
-                employee: employee.id
+                employee: '/employees/' + employee.id
             };
 
             if (sort) {

--- a/src/modules/trackr/employee/sick_days/sickDaysController.js
+++ b/src/modules/trackr/employee/sick_days/sickDaysController.js
@@ -6,7 +6,7 @@ define(['lodash', 'moment'], function(_, moment) {
 
             Restangular.allUrl('sickDays', 'api/sickDays/search/findByEmployee')
                 .getList({
-                    employee: EmployeeService.getEmployee().id
+                    employee: '/employees/' + EmployeeService.getEmployee().id
                 })
                 .then(function(sickDays) {
                     $scope.sickDays = sickDays;

--- a/src/modules/trackr/employee/timesheet/timesheetOverviewController.js
+++ b/src/modules/trackr/employee/timesheet/timesheetOverviewController.js
@@ -21,7 +21,7 @@ define(['lodash', 'moment'], function(_, moment) {
             controller.showMonth = function(date) {
                 Restangular.allUrl('workTimes', 'api/workTimes/search/findByEmployeeAndDateBetweenOrderByDateAscStartTimeAsc')
                     .getList({
-                        employee: UserService.getUser().id,
+                        employee: '/employees/' + UserService.getUser().id,
                         start: moment(date).format('YYYY-MM-DD'),
                         end: moment(date).endOf('month').format('YYYY-MM-DD'),
                         projection: 'withProject'

--- a/src/modules/trackr/employee/vacation/listController.js
+++ b/src/modules/trackr/employee/vacation/listController.js
@@ -6,7 +6,7 @@ define(['lodash'], function(_) {
 
             Restangular.allUrl('vacationRequests', 'api/vacationRequests/search/findByEmployeeOrderByStartDateAsc')
                 .getList({
-                    employee: $scope.employee.id,
+                    employee: '/employees/' + $scope.employee.id,
                     projection: 'withEmployeeAndApprover'
                 }).then(function(vacationRequests) {
                     $scope.vacationRequests = vacationRequests;

--- a/test/backendMock.js
+++ b/test/backendMock.js
@@ -80,9 +80,9 @@ define(['fixtures'], function(fixtures) {
             .respond(fixtures['api/companies']);
         $httpBackend.whenGET(/^api\/companies\/search\/findByCompanyId\?companyId=\w+&projection=\w+$/)
             .respond(function() {
-                var response = fixtures['api/companies'];
-                response._embedded.companies[0].address = fixtures['api/addresses']._embedded.addresses[0];
-                response._embedded.companies[0].contactPersons = fixtures['api/contactPersons']._embedded.contactPersons;
+                var response = fixtures['api/companies']._embedded.companies[0];
+                response.address = fixtures['api/addresses']._embedded.addresses[0];
+                response.contactPersons = fixtures['api/contactPersons']._embedded.contactPersons;
                 return [200, response];
             });
         $httpBackend.whenGET(/^api\/companies\/search\/findByNameLikeIgnoreCaseOrderByNameAsc\?.*/)
@@ -167,7 +167,7 @@ define(['fixtures'], function(fixtures) {
                 });
                 return [200, fixture];
             });
-        $httpBackend.whenGET(/^api\/travelExpenseReports\/search\/findByEmployeeAndStatusOrderByStatusAsc\?page=\d+&projection=\w+&size=\d+&sort=\w*&status=\w+$/)
+        $httpBackend.whenGET(/^api\/travelExpenseReports\/search\/findByEmployeeAndStatusOrderByStatusAsc\?employee=%2Femployees%2F\d+&page=\d+&projection=\w+&size=\d+&sort=\w*&status=\w+$/)
             .respond(fixtures['api/travelExpenseReports']);
         $httpBackend.whenGET(/^api\/travelExpenseReports\/search\/findByStatus\?page=\d+&projection=\w+&size=\d+&sort=[\w,\.]*&status=\w+$/)
             .respond(fixtures['api/travelExpenseReports']);

--- a/test/modules/trackr/employee/expenses/listControllerSpec.js
+++ b/test/modules/trackr/employee/expenses/listControllerSpec.js
@@ -6,6 +6,7 @@ define(['baseTestSetup', 'fixtures', 'angular'], function(baseTestSetup, fixture
         beforeEach(inject(function($rootScope, $controller) {
             scope = $rootScope.$new();
             var employee = {
+                id: 0,
                 _links: { self: {href: ''}}
             };
             state = {


### PR DESCRIPTION
These changes were necessary:
- Finders now take refs as URIs
  
  Finder methods exported by Spring Data REST now need references to
  entities as URIs instead of just ids. So
  `search/findByEmployee?employee=0` becomes
  `search/findByEmployee?employee=/employees/0`.
- Finders don't return lists anymore
  
  Finders exported by Spring Data REST that only have a single return
  value (not a list) in their method signature now correctly return only
  one object, so we can remove the workarounds in the frontend.
